### PR TITLE
fix(migrations): split 009 ALTER for TiDB compatibility

### DIFF
--- a/backend/schemas/migrations/009_add_etymology_origin_forms.up.sql
+++ b/backend/schemas/migrations/009_add_etymology_origin_forms.up.sql
@@ -20,7 +20,15 @@ CREATE TABLE etymology_origin_forms (
 
 -- note_origin_parts.origin_form_id pins the part reference to a specific
 -- form on the referenced origin. NULL means the reference is generic.
+--
+-- TiDB compatibility note: the column ADD and FK ADD have to be separate
+-- ALTER TABLE statements. Combined, TiDB evaluates the FK constraint
+-- before the new column is fully visible in the same ALTER and rejects
+-- the FK with "Error 1072: Key column 'origin_form_id' doesn't exist in
+-- table". MySQL handles the combined form fine; TiDB does not.
 ALTER TABLE note_origin_parts
-    ADD COLUMN origin_form_id BIGINT NULL AFTER origin_id,
+    ADD COLUMN origin_form_id BIGINT NULL AFTER origin_id;
+
+ALTER TABLE note_origin_parts
     ADD CONSTRAINT fk_note_origin_parts_origin_form_id
         FOREIGN KEY (origin_form_id) REFERENCES etymology_origin_forms(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Migration 009 fails on TiDB Cloud because the combined column-add + FK-constraint-add in one \`ALTER TABLE\` runs the FK check before the new column is visible:

\`\`\`
Error 1072 (42000): Key column 'origin_form_id' doesn't exist in table
\`\`\`

MySQL handles the combined form; TiDB does not. Split into two consecutive \`ALTER TABLE\` statements. Behaviour on MySQL is unchanged.

This unblocks subsequent migrations (010, 011, 012) from being applied to TiDB.

## Operator note

If a previous \`langner migrate import-db\` against TiDB left golang-migrate in a dirty state on this migration (\`schema_migrations.dirty = 1\` for version 9), clear it by hand before retrying:

\`\`\`sql
UPDATE schema_migrations SET dirty = 0 WHERE version = 9;
-- or DELETE the row if 009 needs to replay entirely
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [ ] Apply to TiDB and confirm migrations 009 → 011 all land
- [ ] No regression on local MySQL (combined form still works there; the split form just adds a one-shot extra round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)