### PR TITLE
fix(etymology export): keep failing vocabularies when origins are mastered

### DIFF
--- a/backend/internal/notebook/etymology_writer.go
+++ b/backend/internal/notebook/etymology_writer.go
@@ -162,7 +162,18 @@ func (writer EtymologyNotebookWriter) buildChapters(etymIndex EtymologyIndex) ([
 		wordIsSkipped := func(expression string) bool {
 			return writer.expressionIsSkipped(etymIndex.ID, sessionTitle, expression)
 		}
-		defChapters := readDefinitionsFileChapters(defDir, sessionFilename, originMap, needsStudy, wordHasBeenLearned, wordIsSkipped, conceptByExpression, conceptByHead)
+		// Words the user is actively failing (latest vocabulary log is
+		// misunderstood) must stay in the export even when every origin
+		// they reference has reached the next-review date — those are
+		// precisely the words the study material exists for. Without this
+		// gate, taxidermy / pedagogy / similar derived words disappeared
+		// from the WPME PDF after the user mastered taxis + derma /
+		// paidos + agogos despite repeated quiz failures on the words
+		// themselves.
+		wordHasPendingMisunderstanding := func(expression string) bool {
+			return writer.expressionHasPendingMisunderstanding(etymIndex.ID, sessionTitle, expression)
+		}
+		defChapters := readDefinitionsFileChapters(defDir, sessionFilename, originMap, needsStudy, wordHasBeenLearned, wordIsSkipped, wordHasPendingMisunderstanding, conceptByExpression, conceptByHead)
 
 		templateConcepts := buildTemplateConcepts(sessionConcepts, sessionRelations, originMap)
 		if len(defChapters) > 0 {
@@ -483,6 +494,40 @@ func (writer EtymologyNotebookWriter) expressionIsSkipped(etymID, sessionTitle, 
 	return false
 }
 
+// expressionHasPendingMisunderstanding returns true when the most recent
+// log on the derived word — across both vocabulary directions
+// (LearnedLogs and ReverseLogs) — has status `misunderstood`. Used by
+// the etymology PDF / markdown so words the user is currently failing
+// remain in the export even when their underlying origins are fully
+// mastered. Without this signal, taxidermy / pedagogy / similar derived
+// words disappeared from the WPME export the moment taxis + derma or
+// paidos + agogos crossed into long SR intervals, even though the user
+// kept failing the words themselves.
+func (writer EtymologyNotebookWriter) expressionHasPendingMisunderstanding(etymID, sessionTitle, expression string) bool {
+	histories := writer.learningHistories[etymID]
+	if len(histories) == 0 {
+		return false
+	}
+	for _, h := range histories {
+		if h.Metadata.Title != sessionTitle {
+			continue
+		}
+		for _, scene := range h.Scenes {
+			for _, expr := range scene.Expressions {
+				if !strings.EqualFold(expr.Expression, expression) {
+					continue
+				}
+				latest, found := latestEtymologyLog(expr.LearnedLogs, expr.ReverseLogs)
+				if !found {
+					return false
+				}
+				return latest.Status == LearnedStatusMisunderstood
+			}
+		}
+	}
+	return false
+}
+
 func (writer EtymologyNotebookWriter) expressionRecentlyLearned(etymID, sessionTitle, expression string) bool {
 	histories := writer.learningHistories[etymID]
 	if len(histories) == 0 {
@@ -568,6 +613,7 @@ func readDefinitionsFileChapters(
 	needsStudy func(origin string) bool,
 	wordHasBeenLearned func(expression string) bool,
 	wordIsSkipped func(expression string) bool,
+	wordHasPendingMisunderstanding func(expression string) bool,
 	conceptByExpression map[string]string,
 	conceptByHead map[string]DefinitionConceptInfo,
 ) []assets.EtymologyChapter {
@@ -600,22 +646,34 @@ func readDefinitionsFileChapters(
 			seenConceptHead := make(map[string]int) // head -> index in sceneWords
 			var sceneWords []assets.EtymologyWordEntry
 			for _, note := range scene.Expressions {
-				if !wordNeedsStudy(note.OriginParts, needsStudy) {
-					continue
-				}
-				// Also skip words the user already knows. Even when
-				// the word's origins still need work, re-reading a
-				// known word's definition doesn't help drill the
-				// origin; the origins block at the top of the chapter
-				// covers that on its own. Mirrors the vocabulary
-				// PDF's needsToLearnInNotebook semantic: "known" iff
-				// either direction has a recent non-misunderstood log
-				// within its SR interval.
-				if wordHasBeenLearned != nil && wordHasBeenLearned(note.Expression) {
-					continue
-				}
+				// Skip is the user saying "stop studying this" — honor
+				// it before every other gate so a skip always wins.
 				if wordIsSkipped != nil && wordIsSkipped(note.Expression) {
 					continue
+				}
+				// A word the user is actively failing (latest vocab log
+				// is misunderstood) must stay in the export regardless
+				// of origin mastery or whether the other direction is
+				// still within its SR window — that's exactly what the
+				// study material is for. This bypasses both gates
+				// below.
+				wordItselfPending := wordHasPendingMisunderstanding != nil && wordHasPendingMisunderstanding(note.Expression)
+				if !wordItselfPending {
+					// Origin-mastery gate: when every origin the word
+					// references has been mastered, the word is just
+					// noise (the chapter's origins block covers them).
+					if !wordNeedsStudy(note.OriginParts, needsStudy) {
+						continue
+					}
+					// Word-mastery gate: even when origins still need
+					// work, re-reading a known word's definition
+					// doesn't help drill the origins. "Known" mirrors
+					// the vocabulary PDF's needsToLearnInNotebook
+					// semantic: either direction has a recent
+					// non-misunderstood log within its SR interval.
+					if wordHasBeenLearned != nil && wordHasBeenLearned(note.Expression) {
+						continue
+					}
 				}
 				word := assets.EtymologyWordEntry{
 					Expression:    note.Expression,

--- a/backend/internal/notebook/etymology_writer_test.go
+++ b/backend/internal/notebook/etymology_writer_test.go
@@ -588,6 +588,128 @@ notebooks:
 		"a word the user has never touched must remain so the user can still drill its origins in context")
 }
 
+// TestEtymologyNotebookWriter_KeepsWordsWithPendingMisunderstanding pins
+// the regression where derived English words the user was actively
+// failing in the vocabulary quiz (latest learned_logs entry =
+// misunderstood) disappeared from the etymology export the moment every
+// underlying origin reached its next-review date. The origin-mastery
+// gate has to yield to the word's own learning state — otherwise the
+// study material drops exactly the vocabularies the user needs to drill.
+//
+// Fixture mirrors the real reproduction: two origins both fully mastered
+// (recent correct etymology answers with long SR intervals) and one
+// derived word whose latest vocabulary log is misunderstood.
+func TestEtymologyNotebookWriter_KeepsWordsWithPendingMisunderstanding(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	etymDir := filepath.Join(tmpDir, "etymology", "demo-vocab")
+	require.NoError(t, os.MkdirAll(etymDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(etymDir, "index.yml"), []byte(`id: demo-vocab
+kind: Etymology
+name: Demo Vocab
+notebooks:
+  - ./session1.yml
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(etymDir, "session1.yml"), []byte(`metadata:
+  title: "Session 1"
+origins:
+  - origin: alpha-root
+    language: Latin
+    meaning: alpha
+  - origin: beta-root
+    language: Latin
+    meaning: beta
+`), 0o644))
+
+	defDir := filepath.Join(tmpDir, "definitions", "books", "demo-vocab")
+	require.NoError(t, os.MkdirAll(defDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(defDir, "index.yml"), []byte(`id: demo-vocab
+notebooks:
+  - ./session1.yml
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(defDir, "session1.yml"), []byte(`- metadata:
+    title: "Session 1"
+  scenes:
+    - metadata:
+        title: "alpha-root (alpha)"
+      expressions:
+        - expression: failing-word
+          meaning: "user keeps getting this wrong in the vocab quiz"
+          origin_parts:
+            - origin: alpha-root
+            - origin: beta-root
+        - expression: silent-word
+          meaning: "user never touched this word"
+          origin_parts:
+            - origin: alpha-root
+            - origin: beta-root
+`), 0o644))
+
+	// Both origins are mastered: recent correct breakdown answer with a
+	// long interval. Without the pending-misunderstanding bypass the
+	// origin-mastery gate would drop the entire scene.
+	now := time.Now()
+	learningHistories := map[string][]LearningHistory{
+		"demo-vocab": {{
+			Metadata: LearningHistoryMetadata{NotebookID: "demo-vocab", Title: "Session 1"},
+			Scenes: []LearningScene{{
+				Metadata: LearningSceneMetadata{Title: "alpha-root (alpha)"},
+				Expressions: []LearningHistoryExpression{
+					{
+						Expression: "alpha-root",
+						EtymologyBreakdownLogs: []LearningRecord{{
+							Status:       LearnedStatusUnderstood,
+							LearnedAt:    Date{Time: now.Add(-24 * time.Hour)},
+							Quality:      5,
+							QuizType:     string(QuizTypeEtymologyStandard),
+							IntervalDays: 365,
+						}},
+					},
+					{
+						Expression: "beta-root",
+						EtymologyBreakdownLogs: []LearningRecord{{
+							Status:       LearnedStatusUnderstood,
+							LearnedAt:    Date{Time: now.Add(-24 * time.Hour)},
+							Quality:      5,
+							QuizType:     string(QuizTypeEtymologyStandard),
+							IntervalDays: 365,
+						}},
+					},
+					{
+						Expression: "failing-word",
+						LearnedLogs: []LearningRecord{{
+							Status:       LearnedStatusMisunderstood,
+							LearnedAt:    Date{Time: now.Add(-2 * time.Hour)},
+							Quality:      1,
+							QuizType:     string(QuizTypeNotebook),
+							IntervalDays: 1,
+						}},
+					},
+				},
+			}},
+		}},
+	}
+
+	outputDir := filepath.Join(tmpDir, "output")
+	reader, err := NewReader(nil, nil, nil,
+		[]string{filepath.Join(tmpDir, "definitions")},
+		[]string{filepath.Join(tmpDir, "etymology")}, nil)
+	require.NoError(t, err)
+	writer := NewEtymologyNotebookWriter(reader, "",
+		[]string{filepath.Join(tmpDir, "definitions")}, learningHistories)
+	require.NoError(t, writer.OutputEtymologyNotebook("demo-vocab", outputDir, false))
+
+	content, err := os.ReadFile(filepath.Join(outputDir, "demo-vocab.md"))
+	require.NoError(t, err)
+	out := string(content)
+
+	assert.Contains(t, out, "failing-word",
+		"a word whose latest vocabulary log is misunderstood must remain in the export "+
+			"even when every underlying origin has been mastered")
+	assert.NotContains(t, out, "silent-word",
+		"a word the user has never touched whose origins are all mastered must still be omitted")
+}
+
 // TestEtymologyNotebookWriter_HidesSkippedWords pins the bug-fix for
 // the writer not consulting SkippedAt before the previous commit: a
 // word with skipped_at on any vocabulary quiz type kept appearing in


### PR DESCRIPTION
## Summary

- The etymology markdown/PDF dropped derived English words whose origin parts were all past their next-review date, treating "origins mastered" as proof the user no longer needed the word.
- That ignored the word's own learning state: vocab quizzes the user kept failing (e.g. `taxidermy`, `pedagogy`, and other derived words in Word Power Made Easy) disappeared from the export the moment `taxis + derma` / `paidos + agogos` crossed into long SR intervals — even though those words were exactly what the study material exists for.
- `readDefinitionsFileChapters` now takes a `wordHasPendingMisunderstanding` predicate. When a word's latest vocabulary log (across `LearnedLogs + ReverseLogs`) is misunderstood, the writer bypasses both the origin-mastery gate and the `wordHasBeenLearned` gate so the word stays in the export. The skip gate still wins (an explicit "stop studying this" beats everything).

## Reproduction

With the real `/data/notebooks` fixtures, before this fix the Session 5 `derma (skin)` block was entirely missing from `word-power-made-easy.md` — no `taxidermy`, `taxidermist`, `epidermis`, etc. After the fix:

```
### derma (skin)

- **epidermis**: the outermost layer of skin
    - Origins: *epi* (upon, over) + *derma* (skin)
**taxidermy — stuffing of skins of animals**

| Member | Part of speech | Meaning |
|--------|----------------|---------|
| taxidermy | — | stuffing of skins of animals |
| taxidermist | — | one who prepares, stuffs, and mounts the skins of animals |
```

`pachyderm` / `dermatitis` (both with recent correct vocab answers) correctly stay hidden.

## Test plan

- [x] `go test ./internal/notebook/... ./cmd/langner/...` — all pass
- [x] `go vet ./...` — clean
- [x] Existing `TestEtymologyNotebookWriter_HidesSectionsWhoseOriginsAreMastered` still passes (word with no logs + mastered origins still drops)
- [x] Existing `TestEtymologyNotebookWriter_HidesWordsTheUserHasLearned` still passes (word with recent correct logs still drops)
- [x] Existing `TestEtymologyNotebookWriter_HidesSkippedWords` still passes (skip still wins)
- [x] New `TestEtymologyNotebookWriter_KeepsWordsWithPendingMisunderstanding` pins the new rule on a fixture with two fully mastered origins and one word with a recent misunderstood vocab log
- [x] End-to-end run of `langner notebooks etymology word-power-made-easy` against the real `/data/notebooks` directory — `taxidermy`, `taxidermist`, `epidermis` now appear in Session 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)