### PR TITLE
feat: DB-only state — runtime stops reading and writing YAML for user state

### DIFF
--- a/backend/cmd/langner/datasync.go
+++ b/backend/cmd/langner/datasync.go
@@ -74,6 +74,26 @@ func newMigrateImportDBCommand() *cobra.Command {
 				fmt.Printf("  Note origin parts:  %d new, %d skipped\n", result.Etymology.PartsNew, result.Etymology.PartsSkipped)
 			}
 
+			// Seed the DB-only state tables (definitions sessions/scenes,
+			// flashcard decks, per-quiz-type skip flags, etymology origin
+			// logs) from the same YAML the importer just consumed. The
+			// seeder is idempotent so re-runs only insert what's missing.
+			if !opts.DryRun {
+				if seeder := newStateSeederFromConfig(cfg, db, os.Stdout); seeder != nil {
+					stateResult, serr := seeder.SeedAll(ctx)
+					if serr != nil {
+						return fmt.Errorf("seed db-only state: %w", serr)
+					}
+					fmt.Println("\nState Seed Summary:")
+					fmt.Printf("  Definitions sessions: %d new\n", stateResult.DefinitionsSessionsCreated)
+					fmt.Printf("  Definitions scenes:   %d new\n", stateResult.DefinitionsScenesCreated)
+					fmt.Printf("  Flashcard decks:      %d new\n", stateResult.FlashcardDecksCreated)
+					fmt.Printf("  Note skip flags:      %d new\n", stateResult.NoteSkipFlagsCreated)
+					fmt.Printf("  Origin skip flags:    %d new\n", stateResult.OriginSkipFlagsCreated)
+					fmt.Printf("  Etymology logs:       %d new\n", stateResult.EtymologyLogsCreated)
+				}
+			}
+
 			return nil
 		},
 	}
@@ -196,7 +216,15 @@ modifying the database, use "migrate validate-db" instead.`,
 			}
 			fmt.Println("  Import complete.")
 
-			fmt.Println("Step 3: Verifying the roundtrip is lossless...")
+			if seeder := newStateSeederFromConfig(cfg, db, io.Discard); seeder != nil {
+				fmt.Println("Step 3: Seeding DB-only state tables from YAML...")
+				if _, err := seeder.SeedAll(ctx); err != nil {
+					return fmt.Errorf("seed db-only state: %w", err)
+				}
+				fmt.Println("  Seed complete.")
+			}
+
+			fmt.Println("Step 4: Verifying the roundtrip is lossless...")
 			return runRoundTripDiff(ctx, cfg, db, os.Stdout)
 		},
 	}
@@ -328,9 +356,38 @@ func newExporterFromConfig(cfg *config.Config, db *sqlx.DB, outputDir string, wr
 	dictSink := rapidapi.NewJSONDictionaryRepositoryWriter(outputDir)
 
 	exp := datasync.NewExporter(noteRepo, learningRepo, dictRepo, noteSink, learningSink, dictSink, writer)
+	exp = exp.WithEtymologyOrigins(notebook.NewDBEtymologyOriginRepository(db))
 	return exp.WithDefinitionConcepts(
 		notebook.NewDBDefinitionConceptRepository(db),
 		notebook.NewYAMLDefinitionsBookSink(outputDir),
+	)
+}
+
+// newStateSeederFromConfig wires the datasync.StateSeeder used by
+// import-db and sync-db to populate the DB-only state tables from YAML.
+// Returns nil when the notebook reader can't be constructed.
+func newStateSeederFromConfig(cfg *config.Config, db *sqlx.DB, writer io.Writer) *datasync.StateSeeder {
+	reader, err := notebook.NewReader(
+		cfg.Notebooks.StoriesDirectories,
+		cfg.Notebooks.FlashcardsDirectories,
+		cfg.Notebooks.BooksDirectories,
+		cfg.Notebooks.DefinitionsDirectories,
+		cfg.Notebooks.EtymologyDirectories,
+		nil,
+	)
+	if err != nil {
+		return nil
+	}
+	return datasync.NewStateSeeder(
+		reader,
+		notebook.NewDBNoteRepository(db),
+		notebook.NewDBEtymologyOriginRepository(db),
+		notebook.NewDBDefinitionsRepository(db),
+		notebook.NewDBFlashcardDeckRepository(db),
+		notebook.NewDBSkipFlagRepository(db),
+		learning.NewDBLearningRepository(db),
+		learning.NewYAMLLearningRepository(cfg.Notebooks.LearningNotesDirectory, nil),
+		writer,
 	)
 }
 
@@ -408,6 +465,14 @@ func extractNotebookIDs(notes []notebook.NoteRecord) []string {
 //   - notes, etymology_origins, semantic_concepts, definition_concepts, dictionary_entries are leaf parents
 func dataTablesInDeletionOrder() []string {
 	return []string{
+		// DB-only-state tables (migration 017). Skip-flag tables FK to
+		// notes / etymology_origins and the definitions_scenes table FKs
+		// to definitions_sessions, so clear children before parents.
+		"note_skip_flags",
+		"origin_skip_flags",
+		"definitions_scenes",
+		"definitions_sessions",
+		"flashcard_decks",
 		"note_origin_parts",
 		"notebook_notes",
 		"note_images",

--- a/backend/internal/analytics/db_repository.go
+++ b/backend/internal/analytics/db_repository.go
@@ -92,15 +92,19 @@ func (r *DBRepository) DailySummaries(ctx context.Context, rangeDays int, filter
 }
 
 // wrongRow is the projection used for one wrong attempt on the requested day.
+// note_id / origin_id are nullable since migration 017 — exactly one is
+// set per row (vocab logs carry note_id, etymology-origin logs carry
+// origin_id).
 type wrongRow struct {
-	NoteID        int64     `db:"note_id"`
-	Expression    string    `db:"expression"`
-	NotebookID    string    `db:"notebook_id"`
-	NotebookTitle string    `db:"notebook_title"`
-	SceneTitle    string    `db:"scene_title"`
-	QuizType      string    `db:"quiz_type"`
-	LearnedAt     time.Time `db:"learned_at"`
-	Status        string    `db:"status"`
+	NoteID        sql.NullInt64 `db:"note_id"`
+	OriginID      sql.NullInt64 `db:"origin_id"`
+	Expression    string        `db:"expression"`
+	NotebookID    string        `db:"notebook_id"`
+	NotebookTitle string        `db:"notebook_title"`
+	SceneTitle    string        `db:"scene_title"`
+	QuizType      string        `db:"quiz_type"`
+	LearnedAt     time.Time     `db:"learned_at"`
+	Status        string        `db:"status"`
 }
 
 // DayDetail returns the wrong words for the day plus adjacent-day pointers.
@@ -122,12 +126,18 @@ func (r *DBRepository) DayDetail(ctx context.Context, day time.Time, filters Fil
 		return DayDetail{}, err
 	}
 
-	// Wrong attempts on the day. The scene title is fetched via a correlated
-	// subquery rather than a LEFT JOIN so a note belonging to multiple
-	// notebook rows doesn't fan out into duplicate cards.
+	// Wrong attempts on the day. Vocab logs (note_id set) join `notes`
+	// for the usage; etymology-origin logs (origin_id set) join
+	// `etymology_origins` for the origin string. The two are UNIONed so
+	// the Day Detail surfaces both kinds of wrong words. The whereDay
+	// clause is referenced in both halves; PostgreSQL binds each $N
+	// placeholder once and reuses it, so pb.args is passed a single
+	// time. The scene title is a correlated subquery (not a LEFT JOIN)
+	// so a note in multiple notebook rows doesn't fan out.
 	wrongQuery := `
 		SELECT
 			ll.note_id,
+			NULL::bigint AS origin_id,
 			n."usage" AS expression,
 			COALESCE(ll.source_notebook_id, '') AS notebook_id,
 			COALESCE(ll.source_notebook_id, '') AS notebook_title,
@@ -144,7 +154,24 @@ func (r *DBRepository) DayDetail(ctx context.Context, day time.Time, filters Fil
 		JOIN notes n ON n.id = ll.note_id
 		` + whereDay + `
 			AND ll.status = 'misunderstood'
-		ORDER BY n."usage"
+			AND ll.note_id IS NOT NULL
+		UNION ALL
+		SELECT
+			NULL::bigint AS note_id,
+			ll.origin_id,
+			eo.origin AS expression,
+			COALESCE(ll.source_notebook_id, '') AS notebook_id,
+			COALESCE(ll.source_notebook_id, '') AS notebook_title,
+			'' AS scene_title,
+			ll.quiz_type,
+			ll.learned_at,
+			ll.status
+		FROM learning_logs ll
+		JOIN etymology_origins eo ON eo.id = ll.origin_id
+		` + whereDay + `
+			AND ll.status = 'misunderstood'
+			AND ll.origin_id IS NOT NULL
+		ORDER BY expression
 	`
 	var wrongs []wrongRow
 	if err := r.db.SelectContext(ctx, &wrongs, wrongQuery, pb.args...); err != nil {
@@ -155,12 +182,12 @@ func (r *DBRepository) DayDetail(ctx context.Context, day time.Time, filters Fil
 	// helpers can compute the pattern and the streaks around the day's attempt.
 	words := make([]WrongWord, 0, len(wrongs))
 	for _, w := range wrongs {
-		attempts, err := r.recentAttempts(ctx, w.NoteID, w.QuizType, w.LearnedAt)
+		attempts, err := r.recentAttempts(ctx, w.NoteID, w.OriginID, w.QuizType, w.LearnedAt)
 		if err != nil {
 			return DayDetail{}, err
 		}
 		words = append(words, WrongWord{
-			NoteID:                w.NoteID,
+			NoteID:                w.NoteID.Int64,
 			Expression:            w.Expression,
 			NotebookID:            w.NotebookID,
 			NotebookTitle:         w.NotebookTitle,
@@ -229,11 +256,19 @@ func (r *DBRepository) daySummary(ctx context.Context, dayStr string, filters Fi
 
 // recentAttempts returns up to RecentPatternLength most recent attempts for the
 // given (note, quiz_type) on or before upTo (inclusive of upTo).
-func (r *DBRepository) recentAttempts(ctx context.Context, noteID int64, quizType string, upTo time.Time) ([]Attempt, error) {
+func (r *DBRepository) recentAttempts(ctx context.Context, noteID, originID sql.NullInt64, quizType string, upTo time.Time) ([]Attempt, error) {
+	// Key by whichever ID identifies this log: etymology-origin logs by
+	// origin_id, vocab logs by note_id.
+	idCol := "note_id"
+	idVal := noteID.Int64
+	if originID.Valid {
+		idCol = "origin_id"
+		idVal = originID.Int64
+	}
 	query := `
 		SELECT status, learned_at, quality, quiz_type
 		FROM learning_logs
-		WHERE note_id = $1 AND quiz_type = $2 AND learned_at <= $3
+		WHERE ` + idCol + ` = $1 AND quiz_type = $2 AND learned_at <= $3
 		ORDER BY learned_at DESC
 		LIMIT $4
 	`
@@ -243,7 +278,7 @@ func (r *DBRepository) recentAttempts(ctx context.Context, noteID int64, quizTyp
 		Quality   int       `db:"quality"`
 		QuizType  string    `db:"quiz_type"`
 	}
-	if err := r.db.SelectContext(ctx, &rows, query, noteID, quizType, upTo, RecentPatternLength); err != nil {
+	if err := r.db.SelectContext(ctx, &rows, query, idVal, quizType, upTo, RecentPatternLength); err != nil {
 		return nil, fmt.Errorf("recent attempts: %w", err)
 	}
 	out := make([]Attempt, len(rows))

--- a/backend/internal/datasync/datasync.go
+++ b/backend/internal/datasync/datasync.go
@@ -596,10 +596,48 @@ func (imp *Importer) ImportLearningLogs(ctx context.Context, opts ImportOptions)
 		}
 	}
 
-	// First pass: batch-create auto notes for unknown expressions
+	// Build a (notebookID, lowercase origin name) set so any expression
+	// matching a known etymology origin is routed to the StateSeeder
+	// (origin_id logs) instead of being auto-noted here. The user's YAML
+	// frequently omits the `type: origin` marker on roots like "ambi" /
+	// "ascetic" / "epi", so name-matching against etymology_origins is
+	// the reliable signal. Attaching their logs to a NotebookNotes-less
+	// phantom note would drop them on export.
+	originNamesByNotebook := map[string]map[string]bool{}
+	if imp.etymologyOriginRepo != nil {
+		existingOrigins, oerr := imp.etymologyOriginRepo.FindAll(ctx)
+		if oerr != nil {
+			return nil, fmt.Errorf("load etymology origins: %w", oerr)
+		}
+		for _, o := range existingOrigins {
+			byNB := originNamesByNotebook[o.NotebookID]
+			if byNB == nil {
+				byNB = map[string]bool{}
+				originNamesByNotebook[o.NotebookID] = byNB
+			}
+			byNB[strings.ToLower(strings.TrimSpace(o.Origin))] = true
+		}
+	}
+	isKnownOrigin := func(expr exprWithNotebook) bool {
+		if expr.Type == notebook.LearningExpressionTypeOrigin {
+			return true
+		}
+		byNB, ok := originNamesByNotebook[expr.notebookID]
+		if !ok {
+			return false
+		}
+		return byNB[strings.ToLower(strings.TrimSpace(expr.Expression))]
+	}
+
+	// First pass: batch-create auto notes for unknown vocab expressions.
+	// Origin expressions are excluded — the StateSeeder writes their
+	// logs against origin_id.
 	newNoteEntries := make(map[string]bool)
 	var newNotes []*notebook.NoteRecord
 	for _, expr := range allExpressions {
+		if isKnownOrigin(expr) {
+			continue
+		}
 		if noteMap.lookup(expr.Expression, expr.notebookID) == nil && !newNoteEntries[expr.Expression] {
 			newNoteEntries[expr.Expression] = true
 			n := &notebook.NoteRecord{
@@ -628,9 +666,14 @@ func (imp *Importer) ImportLearningLogs(ctx context.Context, opts ImportOptions)
 		imp.touchedNoteIDs = make(map[int64]bool)
 	}
 
-	// Second pass: collect learning logs with correct note IDs
+	// Second pass: collect learning logs with correct note IDs. Origin
+	// expressions are owned by the StateSeeder (origin_id logs) and
+	// skipped here so their logs don't attach to phantom notes.
 	var newLogs []*learning.LearningLog
 	for _, expr := range allExpressions {
+		if isKnownOrigin(expr) {
+			continue
+		}
 		n := noteMap.lookup(expr.Expression, expr.notebookID)
 		if n == nil {
 			continue
@@ -662,7 +705,14 @@ func (imp *Importer) ImportLearningLogs(ctx context.Context, opts ImportOptions)
 		}
 
 		for _, rec := range expr.ReverseLogs {
-			quizType := "reverse"
+			// Preserve the record's own quiz_type — older YAML parks
+			// freeform records inside the reverse_logs slot. Defaulting
+			// to "reverse" only when unspecified keeps the round-trip
+			// lossless (hardcoding it silently reclassifies those).
+			quizType := rec.QuizType
+			if quizType == "" {
+				quizType = "reverse"
+			}
 			key := logKey{n.ID, quizType, rec.LearnedAt.UTC(), expr.notebookID, string(rec.Status)}
 			if existingLogs.matchSource(key) {
 				result.LearningSkipped++
@@ -809,8 +859,19 @@ type NoteSink interface {
 }
 
 // LearningSink writes exported learning logs.
+//
+// origins carries every etymology_origins row so origin-typed logs
+// (NoteID == 0, OriginID != 0) round-trip back into the YAML as
+// `type: origin` expressions. Without it, origin logs survive import
+// (StateSeeder writes them with origin_id) but vanish from the
+// round-trip, and validate-db reports every origin as source=N,
+// exported=0.
 type LearningSink interface {
-	WriteAll(notes []notebook.NoteRecord, logs []learning.LearningLog) error
+	WriteAll(
+		notes []notebook.NoteRecord,
+		logs []learning.LearningLog,
+		origins []notebook.EtymologyOriginRecord,
+	) error
 }
 
 // DictionarySink writes exported dictionary entries.
@@ -856,6 +917,10 @@ type Exporter struct {
 	noteSink       NoteSink
 	learningSink   LearningSink
 	dictionarySink DictionarySink
+	// originRepo is consulted by ExportLearningLogs so origin-typed
+	// LearningHistoryExpression rows round-trip through YAML. Nil means
+	// "no etymology data": origin logs skip the sink.
+	originRepo notebook.EtymologyOriginRepository
 	// Optional definition-concept side. When either is nil,
 	// ExportAll skips the definition-concept phase.
 	definitionConceptRepo notebook.DefinitionConceptRepository
@@ -874,6 +939,14 @@ func NewExporter(noteRepo notebook.NoteRepository, learningRepo learning.Learnin
 		dictionarySink: dictionarySink,
 		writer:         writer,
 	}
+}
+
+// WithEtymologyOrigins wires the etymology_origins repository so
+// ExportLearningLogs hands every origin to the LearningSink. Without
+// this call origin-typed expressions silently drop on round-trip.
+func (exp *Exporter) WithEtymologyOrigins(originRepo notebook.EtymologyOriginRepository) *Exporter {
+	exp.originRepo = originRepo
+	return exp
 }
 
 // WithDefinitionConcepts configures the definitions-concept export
@@ -917,7 +990,15 @@ func (exp *Exporter) ExportLearningLogs(ctx context.Context) (*ExportLearningLog
 		return nil, fmt.Errorf("load learning logs: %w", err)
 	}
 
-	if err := exp.learningSink.WriteAll(notes, logs); err != nil {
+	var origins []notebook.EtymologyOriginRecord
+	if exp.originRepo != nil {
+		origins, err = exp.originRepo.FindAll(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("load etymology origins: %w", err)
+		}
+	}
+
+	if err := exp.learningSink.WriteAll(notes, logs, origins); err != nil {
 		return nil, fmt.Errorf("write learning logs: %w", err)
 	}
 

--- a/backend/internal/datasync/datasync_test.go
+++ b/backend/internal/datasync/datasync_test.go
@@ -1189,8 +1189,8 @@ func TestExporter_ExportLearningLogs(t *testing.T) {
 					{ID: 1, NoteID: 1, Status: "understood", LearnedAt: baseTime, Quality: 4, QuizType: "notebook"},
 					{ID: 2, NoteID: 1, Status: "understood", LearnedAt: baseTime.Add(24 * time.Hour), Quality: 5, QuizType: "reverse"},
 				}, nil)
-				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any()).
-					DoAndReturn(func(notes []notebook.NoteRecord, logs []learning.LearningLog) error {
+				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(notes []notebook.NoteRecord, logs []learning.LearningLog, origins []notebook.EtymologyOriginRecord) error {
 						require.Len(t, notes, 1)
 						require.Len(t, logs, 2)
 						return nil
@@ -1203,7 +1203,7 @@ func TestExporter_ExportLearningLogs(t *testing.T) {
 			setup: func(noteRepo *mock_notebook.MockNoteRepository, learningRepo *mock_learning.MockLearningRepository, learningSink *mock_datasync.MockLearningSink) {
 				noteRepo.EXPECT().FindAll(gomock.Any()).Return([]notebook.NoteRecord{}, nil)
 				learningRepo.EXPECT().FindAll(gomock.Any()).Return([]learning.LearningLog{}, nil)
-				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any()).Return(nil)
+				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			want: &ExportLearningLogsResult{},
 		},
@@ -1227,7 +1227,7 @@ func TestExporter_ExportLearningLogs(t *testing.T) {
 			setup: func(noteRepo *mock_notebook.MockNoteRepository, learningRepo *mock_learning.MockLearningRepository, learningSink *mock_datasync.MockLearningSink) {
 				noteRepo.EXPECT().FindAll(gomock.Any()).Return([]notebook.NoteRecord{}, nil)
 				learningRepo.EXPECT().FindAll(gomock.Any()).Return([]learning.LearningLog{}, nil)
-				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any()).Return(fmt.Errorf("write failed"))
+				learningSink.EXPECT().WriteAll(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("write failed"))
 			},
 			wantErr: true,
 		},

--- a/backend/internal/datasync/state_seed.go
+++ b/backend/internal/datasync/state_seed.go
@@ -1,0 +1,411 @@
+package datasync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/at-ishikawa/langner/internal/learning"
+	"github.com/at-ishikawa/langner/internal/notebook"
+)
+
+// StateSeedResult summarises a SeedState run for the migrate import CLI.
+type StateSeedResult struct {
+	DefinitionsSessionsCreated int
+	DefinitionsScenesCreated   int
+	FlashcardDecksCreated      int
+	NoteSkipFlagsCreated       int
+	OriginSkipFlagsCreated     int
+	EtymologyLogsCreated       int
+}
+
+// StateSeeder populates the migration-016 tables (definitions_sessions /
+// scenes, flashcard_decks, note_skip_flags, origin_skip_flags) plus the
+// etymology rows in learning_logs from the existing YAML. Idempotent:
+// each phase upserts so a re-run skips already-seeded rows.
+type StateSeeder struct {
+	reader        *notebook.Reader
+	noteRepo      notebook.NoteRepository
+	originRepo    notebook.EtymologyOriginRepository
+	defsRepo      notebook.DefinitionsRepository
+	flashcardRepo notebook.FlashcardDeckRepository
+	skipFlagRepo  notebook.SkipFlagRepository
+	learningRepo  learning.LearningRepository
+	learningSrc   LearningSource
+	writer        io.Writer
+}
+
+// NewStateSeeder constructs a seeder. learningSrc is the YAML-side
+// learning history reader used to pull skip flags and etymology logs.
+func NewStateSeeder(
+	reader *notebook.Reader,
+	noteRepo notebook.NoteRepository,
+	originRepo notebook.EtymologyOriginRepository,
+	defsRepo notebook.DefinitionsRepository,
+	flashcardRepo notebook.FlashcardDeckRepository,
+	skipFlagRepo notebook.SkipFlagRepository,
+	learningRepo learning.LearningRepository,
+	learningSrc LearningSource,
+	writer io.Writer,
+) *StateSeeder {
+	return &StateSeeder{
+		reader:        reader,
+		noteRepo:      noteRepo,
+		originRepo:    originRepo,
+		defsRepo:      defsRepo,
+		flashcardRepo: flashcardRepo,
+		skipFlagRepo:  skipFlagRepo,
+		learningRepo:  learningRepo,
+		learningSrc:   learningSrc,
+		writer:        writer,
+	}
+}
+
+// SeedAll runs every seed phase and returns aggregated counts.
+func (s *StateSeeder) SeedAll(ctx context.Context) (*StateSeedResult, error) {
+	result := &StateSeedResult{}
+
+	if err := s.seedDefinitions(ctx, result); err != nil {
+		return result, fmt.Errorf("seed definitions structure: %w", err)
+	}
+	if err := s.seedFlashcards(ctx, result); err != nil {
+		return result, fmt.Errorf("seed flashcard decks: %w", err)
+	}
+	if err := s.seedSkipFlagsAndEtymologyLogs(ctx, result); err != nil {
+		return result, fmt.Errorf("seed skip flags and etymology logs: %w", err)
+	}
+	return result, nil
+}
+
+func (s *StateSeeder) seedDefinitions(ctx context.Context, result *StateSeedResult) error {
+	if s.reader == nil || s.defsRepo == nil {
+		return nil
+	}
+	for _, bookID := range s.reader.GetDefinitionsBookIDs() {
+		books, ok := s.reader.GetDefinitionsBook(bookID)
+		if !ok {
+			continue
+		}
+		for _, book := range books {
+			title := book.Metadata.Title
+			if title == "" {
+				title = book.Metadata.Notebook
+			}
+			if title == "" {
+				continue
+			}
+			var date *time.Time
+			if !book.Metadata.Date.IsZero() {
+				d := book.Metadata.Date
+				date = &d
+			}
+			session, err := s.defsRepo.FindOrCreateSession(ctx, bookID, title, book.Metadata.Notebook, date)
+			if err != nil {
+				return fmt.Errorf("upsert session %q: %w", title, err)
+			}
+			if session.CreatedAt.Equal(session.UpdatedAt) {
+				result.DefinitionsSessionsCreated++
+			}
+			for _, scene := range book.Scenes {
+				idx := scene.Metadata.GetIndex()
+				rec, err := s.defsRepo.FindOrCreateScene(ctx, session.ID, idx, scene.Metadata.Title)
+				if err != nil {
+					return fmt.Errorf("upsert scene idx=%d under %q: %w", idx, title, err)
+				}
+				if rec.CreatedAt.Equal(rec.UpdatedAt) {
+					result.DefinitionsScenesCreated++
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (s *StateSeeder) seedFlashcards(ctx context.Context, result *StateSeedResult) error {
+	if s.reader == nil || s.flashcardRepo == nil {
+		return nil
+	}
+	for nbID := range s.reader.GetFlashcardIndexes() {
+		decks, err := s.reader.ReadFlashcardNotebooks(nbID)
+		if err != nil {
+			continue
+		}
+		for _, deck := range decks {
+			if deck.Title == "" {
+				continue
+			}
+			var date *time.Time
+			if !deck.Date.IsZero() {
+				d := deck.Date
+				date = &d
+			}
+			rec, ferr := s.flashcardRepo.FindOrCreate(ctx, nbID, deck.Title, deck.Description, date)
+			if ferr != nil {
+				return fmt.Errorf("upsert flashcard deck %q in %q: %w", deck.Title, nbID, ferr)
+			}
+			if rec.CreatedAt.Equal(rec.UpdatedAt) {
+				result.FlashcardDecksCreated++
+			}
+		}
+	}
+	return nil
+}
+
+// seedSkipFlagsAndEtymologyLogs walks the on-disk LearningHistory tree
+// once. Each expression contributes:
+//   - one note_skip_flags row per (quizType, timestamp) in SkippedAt,
+//     or one origin_skip_flags row when the expression is an origin
+//   - one learning_logs row per EtymologyBreakdownLogs / EtymologyAssemblyLogs
+//     entry (these are the rows the old SaveEtymologyOriginResult wrote
+//     to YAML; migration 016 made them DB-backed via origin_id)
+func (s *StateSeeder) seedSkipFlagsAndEtymologyLogs(ctx context.Context, result *StateSeedResult) error {
+	if s.learningSrc == nil {
+		return nil
+	}
+	notes, err := s.noteRepo.FindAll(ctx)
+	if err != nil {
+		return fmt.Errorf("load notes: %w", err)
+	}
+	noteIDByExpr := make(map[noteExprKey]int64, len(notes))
+	for _, n := range notes {
+		for _, nn := range n.NotebookNotes {
+			key := noteExprKey{
+				notebookID: nn.NotebookID,
+				expression: strings.ToLower(strings.TrimSpace(n.Entry)),
+			}
+			noteIDByExpr[key] = n.ID
+			if n.Usage != n.Entry {
+				key.expression = strings.ToLower(strings.TrimSpace(n.Usage))
+				noteIDByExpr[key] = n.ID
+			}
+		}
+	}
+
+	var origins []notebook.EtymologyOriginRecord
+	if s.originRepo != nil {
+		origins, err = s.originRepo.FindAll(ctx)
+		if err != nil {
+			return fmt.Errorf("load etymology origins: %w", err)
+		}
+	}
+	originIDByKey := make(map[etyKey]int64, len(origins))
+	for _, o := range origins {
+		originIDByKey[etyKey{
+			notebookID:   o.NotebookID,
+			sessionTitle: o.SessionTitle,
+			origin:       strings.ToLower(strings.TrimSpace(o.Origin)),
+		}] = o.ID
+	}
+
+	// LearningSource only supports per-notebook reads. The reader's
+	// indexes give us the universe of notebook IDs to walk.
+	seenIDs := make(map[string]bool)
+	collect := func(ids ...string) {
+		for _, id := range ids {
+			if id != "" {
+				seenIDs[id] = true
+			}
+		}
+	}
+	if s.reader != nil {
+		for id := range s.reader.GetStoryIndexes() {
+			collect(id)
+		}
+		for id := range s.reader.GetFlashcardIndexes() {
+			collect(id)
+		}
+		for _, id := range s.reader.GetDefinitionsBookIDs() {
+			collect(id)
+		}
+		for id := range s.reader.GetEtymologyIndexes() {
+			collect(id)
+		}
+	}
+
+	for nbID := range seenIDs {
+		exprs, err := s.learningSrc.FindByNotebookID(nbID)
+		if err != nil || len(exprs) == 0 {
+			continue
+		}
+		for _, expr := range exprs {
+			if err := s.persistSkipFlagsForExpression(ctx, nbID, expr, noteIDByExpr, originIDByKey, result); err != nil {
+				return err
+			}
+			if err := s.persistEtymologyLogsForExpression(ctx, nbID, expr, originIDByKey, result); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type noteExprKey struct {
+	notebookID string
+	expression string
+}
+
+type etyKey struct {
+	notebookID   string
+	sessionTitle string
+	origin       string
+}
+
+func (s *StateSeeder) persistSkipFlagsForExpression(
+	ctx context.Context,
+	nbID string,
+	expr notebook.LearningHistoryExpression,
+	noteIDByExpr map[noteExprKey]int64,
+	originIDByKey map[etyKey]int64,
+	result *StateSeedResult,
+) error {
+	if len(expr.SkippedAt) == 0 {
+		return nil
+	}
+
+	if expr.Type == notebook.LearningExpressionTypeOrigin {
+		// Origin entries hung off etymology sessions — match against
+		// every origin sharing the notebook + origin name. Without a
+		// session title carried on the expression we widen the match.
+		for k, id := range originIDByKey {
+			if k.notebookID != nbID {
+				continue
+			}
+			if k.origin != strings.ToLower(strings.TrimSpace(expr.Expression)) {
+				continue
+			}
+			for quizType, ts := range expr.SkippedAt {
+				at := parseSkippedTimestamp(ts)
+				if err := s.skipFlagRepo.SkipOrigin(ctx, id, quizType, at); err != nil {
+					return fmt.Errorf("seed origin skip flag: %w", err)
+				}
+				result.OriginSkipFlagsCreated++
+			}
+		}
+		return nil
+	}
+
+	noteID := noteIDByExpr[noteExprKey{nbID, strings.ToLower(strings.TrimSpace(expr.Expression))}]
+	if noteID == 0 {
+		return nil
+	}
+	for quizType, ts := range expr.SkippedAt {
+		at := parseSkippedTimestamp(ts)
+		if err := s.skipFlagRepo.SkipNote(ctx, noteID, quizType, at); err != nil {
+			return fmt.Errorf("seed note skip flag: %w", err)
+		}
+		result.NoteSkipFlagsCreated++
+	}
+	return nil
+}
+
+// persistEtymologyLogsForExpression writes every YAML log slot for an
+// origin-typed expression against etymology_origins.id. Vocab
+// expressions are handled by ImportLearningLogs; origin expressions
+// are intentionally skipped there because attaching their logs to a
+// note_id-keyed phantom note loses them on export (the note has no
+// NotebookNotes to belong to, so the export's per-notebook YAML walk
+// never visits it).
+//
+// All four slots — LearnedLogs, ReverseLogs, EtymologyBreakdownLogs,
+// EtymologyAssemblyLogs — get the same treatment. Each record's
+// quiz_type is preserved exactly, falling back to the per-slot default
+// only when the record itself didn't specify one. That keeps round-
+// trip lossless against YAML that parks freeform/etymology_freeform
+// records in any slot.
+func (s *StateSeeder) persistEtymologyLogsForExpression(
+	ctx context.Context,
+	nbID string,
+	expr notebook.LearningHistoryExpression,
+	originIDByKey map[etyKey]int64,
+	result *StateSeedResult,
+) error {
+	if s.learningRepo == nil {
+		return nil
+	}
+	if len(expr.LearnedLogs) == 0 && len(expr.ReverseLogs) == 0 &&
+		len(expr.EtymologyBreakdownLogs) == 0 && len(expr.EtymologyAssemblyLogs) == 0 {
+		return nil
+	}
+	// Match the origin by (notebookID, lower(origin)). Without a session
+	// title in the expression we accept the first match — the YAML was
+	// ambiguous anyway and the migrate command is one-shot.
+	//
+	// The expression doesn't need an explicit `type: origin` marker.
+	// Some entries in the user's learning_notes (e.g. "ambi", "ascetic")
+	// omit it but still refer to a Latin/Greek root that exists in
+	// etymology_origins. Anything whose name resolves to an origin row
+	// in the notebook gets routed here; ImportLearningLogs uses the
+	// same predicate to skip those expressions on the note-side.
+	var originID int64
+	for k, id := range originIDByKey {
+		if k.notebookID != nbID {
+			continue
+		}
+		if k.origin != strings.ToLower(strings.TrimSpace(expr.Expression)) {
+			continue
+		}
+		originID = id
+		break
+	}
+	if originID == 0 {
+		return nil
+	}
+
+	writeLogs := func(records []notebook.LearningRecord, defaultQuizType notebook.QuizType) error {
+		for _, r := range records {
+			quizType := string(r.QuizType)
+			if quizType == "" {
+				quizType = string(defaultQuizType)
+			}
+			log := &learning.LearningLog{
+				OriginID:         originID,
+				Status:           string(r.Status),
+				LearnedAt:        r.LearnedAt.Time,
+				Quality:          r.Quality,
+				ResponseTimeMs:   int(r.ResponseTimeMs),
+				QuizType:         quizType,
+				IntervalDays:     r.IntervalDays,
+				SourceNotebookID: nbID,
+			}
+			if err := s.learningRepo.Create(ctx, log); err != nil {
+				return fmt.Errorf("insert etymology log: %w", err)
+			}
+			result.EtymologyLogsCreated++
+		}
+		return nil
+	}
+
+	if err := writeLogs(expr.LearnedLogs, notebook.QuizTypeNotebook); err != nil {
+		return err
+	}
+	if err := writeLogs(expr.ReverseLogs, notebook.QuizTypeReverse); err != nil {
+		return err
+	}
+	if err := writeLogs(expr.EtymologyBreakdownLogs, notebook.QuizTypeEtymologyStandard); err != nil {
+		return err
+	}
+	// An etymology_freeform answer is mirrored into BOTH the breakdown
+	// and assembly YAML slots because both directions were exercised.
+	// On the DB side that's one event, already written via the
+	// breakdown loop, so drop the assembly freeform mirror. Mirrors the
+	// dedup ImportLearningLogs applies for vocab notes — without it,
+	// sync-db's re-import doubles every etymology_freeform origin log
+	// and validate-db catches it on the round-trip.
+	assemblyLogs := expr.EtymologyAssemblyLogs
+	if len(assemblyLogs) > 0 && anyFreeformIn(expr.EtymologyBreakdownLogs) {
+		assemblyLogs = filterOutFreeform(assemblyLogs)
+	}
+	if err := writeLogs(assemblyLogs, notebook.QuizTypeEtymologyReverse); err != nil {
+		return err
+	}
+	return nil
+}
+
+func parseSkippedTimestamp(raw string) time.Time {
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t
+	}
+	return time.Now()
+}

--- a/backend/internal/datasync/validate.go
+++ b/backend/internal/datasync/validate.go
@@ -94,8 +94,16 @@ func buildLearningStats(learningByNotebook map[string][]notebook.LearningHistory
 				es = &LearningExpressionStats{}
 				exprStats[key] = es
 			}
-			es.LearnedLogCount += len(expr.LearnedLogs)
-			es.ReverseLogCount += len(expr.ReverseLogs)
+			// Count each record in the learned/reverse slots by its
+			// quiz_type, not by which slot it sits in. Older YAML parks
+			// freeform records in the reverse_logs slot; import preserves
+			// their quiz_type and export routes them back to learned_logs
+			// (buildExpression's convention). Counting by slot membership
+			// would then show source reverse=1 / exported reverse=0. The
+			// etymology_breakdown / etymology_assembly slots are left
+			// uncounted, matching the pre-existing behaviour.
+			tallyByQuizType(es, expr.LearnedLogs, notebook.QuizTypeNotebook)
+			tallyByQuizType(es, expr.ReverseLogs, notebook.QuizTypeReverse)
 		}
 		result[nbID] = exprStats
 	}
@@ -318,4 +326,28 @@ func mergeStringKeys[V any](a, b map[string]V) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// tallyByQuizType routes each record into the learned or reverse count
+// by its quiz_type, falling back to defaultQuizType when the record
+// didn't specify one. reverse counts as reverse; etymology_breakdown /
+// etymology_assembly are not tallied here (they live in their own YAML
+// slots and aren't part of the learned/reverse round-trip counts);
+// everything else (notebook, freeform, etymology_freeform) counts as
+// learned — matching buildExpression's slot routing on export.
+func tallyByQuizType(es *LearningExpressionStats, recs []notebook.LearningRecord, defaultQuizType notebook.QuizType) {
+	for _, rec := range recs {
+		qt := notebook.QuizType(rec.QuizType)
+		if qt == "" {
+			qt = defaultQuizType
+		}
+		switch qt {
+		case notebook.QuizTypeReverse:
+			es.ReverseLogCount++
+		case notebook.QuizTypeEtymologyStandard, notebook.QuizTypeEtymologyReverse:
+			// not counted in learned/reverse
+		default:
+			es.LearnedLogCount++
+		}
+	}
 }

--- a/backend/internal/learning/history_loader.go
+++ b/backend/internal/learning/history_loader.go
@@ -1,0 +1,376 @@
+package learning
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/at-ishikawa/langner/internal/notebook"
+)
+
+// HistoryStore returns the LearningHistory shape handlers and quiz code
+// expect, but from the database instead of the YAML files in
+// learning_notes/. The runtime swap from YAML to DB happens by
+// replacing notebook.NewLearningHistories(dir) calls with a HistoryStore
+// instance — the result map shape is identical so downstream consumers
+// (filters, validators, handlers) don't have to change.
+type HistoryStore interface {
+	// LoadAll returns every notebook's histories keyed by notebook ID.
+	// Mirrors notebook.NewLearningHistories return shape so the swap is
+	// drop-in.
+	LoadAll(ctx context.Context) (map[string][]notebook.LearningHistory, error)
+}
+
+// DBHistoryStore composes the DB repositories needed to reconstruct the
+// learning_notes/*.yml view from rows.
+type DBHistoryStore struct {
+	noteRepo      notebook.NoteRepository
+	learningRepo  LearningRepository
+	originRepo    notebook.EtymologyOriginRepository
+	skipFlagRepo  notebook.SkipFlagRepository
+}
+
+// NewDBHistoryStore constructs the store. originRepo is optional — pass
+// nil when etymology data isn't present; origin-typed expressions will
+// just be omitted.
+func NewDBHistoryStore(noteRepo notebook.NoteRepository, learningRepo LearningRepository, originRepo notebook.EtymologyOriginRepository, skipFlagRepo notebook.SkipFlagRepository) *DBHistoryStore {
+	return &DBHistoryStore{
+		noteRepo:     noteRepo,
+		learningRepo: learningRepo,
+		originRepo:   originRepo,
+		skipFlagRepo: skipFlagRepo,
+	}
+}
+
+// LoadAll rebuilds the per-notebook LearningHistory map from DB rows.
+// Story notebooks land in the .Scenes shape (one LearningScene per
+// notebook_notes.subgroup); flashcard notebooks land in the flat
+// .Expressions shape with Metadata.Type = "flashcard".
+func (s *DBHistoryStore) LoadAll(ctx context.Context) (map[string][]notebook.LearningHistory, error) {
+	notes, err := s.noteRepo.FindAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load notes: %w", err)
+	}
+
+	logs, err := s.learningRepo.FindAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load learning logs: %w", err)
+	}
+
+	// Bucket logs by their target. Vocab logs key on note_id; etymology
+	// logs key on origin_id. ImportLearningLogs (legacy path) routed every
+	// expression — vocab AND origin — through note_id with a synthetic
+	// note when no notebook_notes link existed; mergeOriginHistories below
+	// re-attaches those orphan etymology logs to the matching origin so
+	// the reconstructed shape matches what the YAML reader produced.
+	logsByNote := make(map[int64][]LearningLog, len(logs))
+	logsByOrigin := make(map[int64][]LearningLog)
+	for _, l := range logs {
+		if l.NoteID != 0 {
+			logsByNote[l.NoteID] = append(logsByNote[l.NoteID], l)
+			continue
+		}
+		if l.OriginID != 0 {
+			logsByOrigin[l.OriginID] = append(logsByOrigin[l.OriginID], l)
+		}
+	}
+
+	// orphanNoteLogsByName lets mergeOriginHistories find logs the
+	// legacy importer stashed on synthetic notes (Usage = origin name,
+	// no notebook_notes link). Keyed by lower(Usage).
+	orphanNoteLogsByName := make(map[string][]LearningLog)
+	for _, n := range notes {
+		if len(n.NotebookNotes) > 0 {
+			continue
+		}
+		ls := logsByNote[n.ID]
+		if len(ls) == 0 {
+			continue
+		}
+		orphanNoteLogsByName[strings.ToLower(strings.TrimSpace(n.Usage))] = append(
+			orphanNoteLogsByName[strings.ToLower(strings.TrimSpace(n.Usage))], ls...,
+		)
+	}
+
+	noteIDs := make([]int64, 0, len(notes))
+	for _, n := range notes {
+		noteIDs = append(noteIDs, n.ID)
+	}
+	noteSkipFlags, err := s.skipFlagRepo.FindNoteFlags(ctx, noteIDs)
+	if err != nil {
+		return nil, fmt.Errorf("load note skip flags: %w", err)
+	}
+	skipFlagsByNote := make(map[int64]notebook.SkippedAtMap, len(noteSkipFlags))
+	for _, f := range noteSkipFlags {
+		m := skipFlagsByNote[f.NoteID]
+		if m == nil {
+			m = make(notebook.SkippedAtMap)
+		}
+		m[f.QuizType] = f.SkippedAt.UTC().Format(time.RFC3339)
+		skipFlagsByNote[f.NoteID] = m
+	}
+
+	histories := make(map[string][]notebook.LearningHistory)
+	buildVocabHistories(notes, logsByNote, skipFlagsByNote, histories)
+
+	if s.originRepo != nil {
+		origins, oerr := s.originRepo.FindAll(ctx)
+		if oerr != nil {
+			return nil, fmt.Errorf("load etymology origins: %w", oerr)
+		}
+		originIDs := make([]int64, 0, len(origins))
+		for _, o := range origins {
+			originIDs = append(originIDs, o.ID)
+		}
+		originSkipFlags, oferr := s.skipFlagRepo.FindOriginFlags(ctx, originIDs)
+		if oferr != nil {
+			return nil, fmt.Errorf("load origin skip flags: %w", oferr)
+		}
+		skipFlagsByOrigin := make(map[int64]notebook.SkippedAtMap, len(originSkipFlags))
+		for _, f := range originSkipFlags {
+			m := skipFlagsByOrigin[f.OriginID]
+			if m == nil {
+				m = make(notebook.SkippedAtMap)
+			}
+			m[f.QuizType] = f.SkippedAt.UTC().Format(time.RFC3339)
+			skipFlagsByOrigin[f.OriginID] = m
+		}
+		mergeOriginHistories(origins, logsByOrigin, orphanNoteLogsByName, skipFlagsByOrigin, histories)
+	}
+
+	return histories, nil
+}
+
+// buildVocabHistories walks notes + their notebook_notes links and
+// materialises a LearningHistory per (notebook, event) — scenes hang off
+// notebook_notes.subgroup. Flashcard notebooks collapse all expressions
+// into the flat .Expressions slice with Metadata.Type = "flashcard".
+func buildVocabHistories(
+	notes []notebook.NoteRecord,
+	logsByNote map[int64][]LearningLog,
+	skipFlagsByNote map[int64]notebook.SkippedAtMap,
+	out map[string][]notebook.LearningHistory,
+) {
+	type historyKey struct {
+		notebookID string
+		title      string
+	}
+	type sceneKey struct {
+		notebookID string
+		title      string
+		scene      string
+	}
+
+	// Preserve the order notes were inserted under each (notebookID,
+	// title, scene) bucket so the output is deterministic.
+	titleOrder := make(map[string][]historyKey)
+	sceneOrder := make(map[historyKey][]sceneKey)
+	seenTitles := make(map[historyKey]bool)
+	seenScenes := make(map[sceneKey]bool)
+
+	titleType := make(map[historyKey]string)
+	exprByScene := make(map[sceneKey][]notebook.LearningHistoryExpression)
+	flashcardExprByTitle := make(map[historyKey][]notebook.LearningHistoryExpression)
+
+	for _, n := range notes {
+		expr := newExpressionFromNote(n, logsByNote[n.ID], skipFlagsByNote[n.ID])
+		for _, nn := range n.NotebookNotes {
+			hk := historyKey{nn.NotebookID, nn.Group}
+			if !seenTitles[hk] {
+				seenTitles[hk] = true
+				titleOrder[nn.NotebookID] = append(titleOrder[nn.NotebookID], hk)
+			}
+			titleType[hk] = nn.NotebookType
+			if nn.NotebookType == "flashcard" {
+				flashcardExprByTitle[hk] = append(flashcardExprByTitle[hk], expr)
+				continue
+			}
+			sk := sceneKey{nn.NotebookID, nn.Group, nn.Subgroup}
+			if !seenScenes[sk] {
+				seenScenes[sk] = true
+				sceneOrder[hk] = append(sceneOrder[hk], sk)
+			}
+			exprByScene[sk] = append(exprByScene[sk], expr)
+		}
+	}
+
+	notebookIDs := make([]string, 0, len(titleOrder))
+	for id := range titleOrder {
+		notebookIDs = append(notebookIDs, id)
+	}
+	sort.Strings(notebookIDs)
+
+	for _, nbID := range notebookIDs {
+		for _, hk := range titleOrder[nbID] {
+			nbType := titleType[hk]
+			if nbType == "flashcard" {
+				out[nbID] = append(out[nbID], notebook.LearningHistory{
+					Metadata: notebook.LearningHistoryMetadata{
+						NotebookID: nbID,
+						Title:      hk.title,
+						Type:       "flashcard",
+					},
+					Expressions: flashcardExprByTitle[hk],
+				})
+				continue
+			}
+			var scenes []notebook.LearningScene
+			for _, sk := range sceneOrder[hk] {
+				scenes = append(scenes, notebook.LearningScene{
+					Metadata:    notebook.LearningSceneMetadata{Title: sk.scene},
+					Expressions: exprByScene[sk],
+				})
+			}
+			out[nbID] = append(out[nbID], notebook.LearningHistory{
+				Metadata: notebook.LearningHistoryMetadata{
+					NotebookID: nbID,
+					Title:      hk.title,
+				},
+				Scenes: scenes,
+			})
+		}
+	}
+}
+
+// mergeOriginHistories adds origin-typed LearningHistoryExpression rows
+// into the existing per-notebook histories. Origins land in the scene
+// matching their (notebook_id, session_title) tuple — same convention
+// the YAML reader used.
+func mergeOriginHistories(
+	origins []notebook.EtymologyOriginRecord,
+	logsByOrigin map[int64][]LearningLog,
+	orphanLogsByName map[string][]LearningLog,
+	skipFlagsByOrigin map[int64]notebook.SkippedAtMap,
+	out map[string][]notebook.LearningHistory,
+) {
+	for _, o := range origins {
+		// Combine logs the importer wrote with origin_id (forward-only
+		// path) and those it stashed on a synthetic note keyed by name
+		// (legacy path). Same origin may have both kinds during the
+		// transition window.
+		logs := append([]LearningLog{}, logsByOrigin[o.ID]...)
+		if orphan := orphanLogsByName[strings.ToLower(strings.TrimSpace(o.Origin))]; len(orphan) > 0 {
+			logs = append(logs, orphan...)
+		}
+		expr := newExpressionFromOrigin(o, logs, skipFlagsByOrigin[o.ID])
+		histories := out[o.NotebookID]
+		matched := false
+		for i := range histories {
+			if !sessionMatches(histories[i], o.SessionTitle) {
+				continue
+			}
+			matched = true
+			for j := range histories[i].Scenes {
+				if histories[i].Scenes[j].Metadata.Title == o.SessionTitle {
+					histories[i].Scenes[j].Expressions = append(histories[i].Scenes[j].Expressions, expr)
+					goto next
+				}
+			}
+			histories[i].Scenes = append(histories[i].Scenes, notebook.LearningScene{
+				Metadata:    notebook.LearningSceneMetadata{Title: o.SessionTitle},
+				Expressions: []notebook.LearningHistoryExpression{expr},
+			})
+		next:
+		}
+		if !matched {
+			histories = append(histories, notebook.LearningHistory{
+				Metadata: notebook.LearningHistoryMetadata{NotebookID: o.NotebookID, Title: o.SessionTitle},
+				Scenes: []notebook.LearningScene{{
+					Metadata:    notebook.LearningSceneMetadata{Title: o.SessionTitle},
+					Expressions: []notebook.LearningHistoryExpression{expr},
+				}},
+			})
+		}
+		out[o.NotebookID] = histories
+	}
+}
+
+func sessionMatches(h notebook.LearningHistory, sessionTitle string) bool {
+	if strings.EqualFold(h.Metadata.Title, sessionTitle) {
+		return true
+	}
+	for _, sc := range h.Scenes {
+		if strings.EqualFold(sc.Metadata.Title, sessionTitle) {
+			return true
+		}
+	}
+	return false
+}
+
+func newExpressionFromNote(n notebook.NoteRecord, logs []LearningLog, skipFlags notebook.SkippedAtMap) notebook.LearningHistoryExpression {
+	entry := n.Entry
+	if entry == "" {
+		entry = n.Usage
+	}
+	exp := buildExpressionFromDBOrder(entry, logs)
+	exp.Type = notebook.LearningExpressionTypeVocabulary
+	exp.SkippedAt = skipFlags
+	return exp
+}
+
+func newExpressionFromOrigin(o notebook.EtymologyOriginRecord, logs []LearningLog, skipFlags notebook.SkippedAtMap) notebook.LearningHistoryExpression {
+	exp := buildExpressionFromDBOrder(o.Origin, logs)
+	exp.Type = notebook.LearningExpressionTypeOrigin
+	exp.SkippedAt = skipFlags
+	return exp
+}
+
+// buildExpressionFromDBOrder is the DB-side companion to
+// learning.buildExpression. The YAML reader keeps records in their YAML
+// array order ("first" is "newest" — new entries are PREPENDED on write).
+// Logs land in the DB during import in YAML order; their primary key is
+// monotonically increasing, so ORDER BY id ASC reproduces the YAML array
+// order. We therefore split logs into the per-quiz-type buckets without
+// re-sorting so callers' GetLatestStatus / GetLatestLogs sees the same
+// [0] entry the YAML loader would have surfaced.
+func buildExpressionFromDBOrder(expression string, logs []LearningLog) notebook.LearningHistoryExpression {
+	var learnedLogs, reverseLogs, breakdownLogs, assemblyLogs []notebook.LearningRecord
+	convert := func(l LearningLog) notebook.LearningRecord {
+		return notebook.LearningRecord{
+			Status:         notebook.LearnedStatus(l.Status),
+			LearnedAt:      notebook.NewDate(l.LearnedAt),
+			Quality:        l.Quality,
+			ResponseTimeMs: int64(l.ResponseTimeMs),
+			QuizType:       l.QuizType,
+			IntervalDays:   l.IntervalDays,
+		}
+	}
+	for _, l := range logs {
+		rec := convert(l)
+		switch l.QuizType {
+		case string(notebook.QuizTypeReverse):
+			reverseLogs = append(reverseLogs, rec)
+		case string(notebook.QuizTypeFreeform):
+			// Freeform tests both directions: append to LearnedLogs
+			// AND ReverseLogs so GetLogsForQuizType returns the entry
+			// regardless of which slot the caller queries. Mirrors how
+			// SaveResult's updater wrote two records when the YAML
+			// path was authoritative.
+			learnedLogs = append(learnedLogs, rec)
+			reverseLogs = append(reverseLogs, rec)
+		case string(notebook.QuizTypeEtymologyStandard):
+			breakdownLogs = append(breakdownLogs, rec)
+		case string(notebook.QuizTypeEtymologyReverse):
+			assemblyLogs = append(assemblyLogs, rec)
+		case string(notebook.QuizTypeEtymologyFreeform):
+			// Etymology Freeform writes a single DB row with this
+			// quiz_type; SetLogsForQuizType / GetLogsForQuizType
+			// expect both etymology slots populated. Duplicate the
+			// record into both so a follow-up Override or read sees
+			// the entry on either lookup side.
+			breakdownLogs = append(breakdownLogs, rec)
+			assemblyLogs = append(assemblyLogs, rec)
+		default:
+			learnedLogs = append(learnedLogs, rec)
+		}
+	}
+	return notebook.LearningHistoryExpression{
+		Expression:             expression,
+		LearnedLogs:            learnedLogs,
+		ReverseLogs:            reverseLogs,
+		EtymologyBreakdownLogs: breakdownLogs,
+		EtymologyAssemblyLogs:  assemblyLogs,
+	}
+}

--- a/backend/internal/learning/history_loader.go
+++ b/backend/internal/learning/history_loader.go
@@ -26,10 +26,10 @@ type HistoryStore interface {
 // DBHistoryStore composes the DB repositories needed to reconstruct the
 // learning_notes/*.yml view from rows.
 type DBHistoryStore struct {
-	noteRepo      notebook.NoteRepository
-	learningRepo  LearningRepository
-	originRepo    notebook.EtymologyOriginRepository
-	skipFlagRepo  notebook.SkipFlagRepository
+	noteRepo     notebook.NoteRepository
+	learningRepo LearningRepository
+	originRepo   notebook.EtymologyOriginRepository
+	skipFlagRepo notebook.SkipFlagRepository
 }
 
 // NewDBHistoryStore constructs the store. originRepo is optional — pass

--- a/backend/internal/learning/model.go
+++ b/backend/internal/learning/model.go
@@ -6,6 +6,12 @@ import "time"
 type LearningLog struct {
 	ID             int64     `db:"id"`
 	NoteID         int64     `db:"note_id"`
+	// OriginID targets an etymology_origins row instead of a note.
+	// Exactly one of NoteID / OriginID is non-zero: vocab logs set
+	// NoteID, etymology-origin logs set OriginID. Migration 017 made
+	// note_id nullable and added origin_id so both quiz kinds share
+	// one logs table.
+	OriginID       int64     `db:"origin_id"`
 	Status         string    `db:"status"`
 	LearnedAt      time.Time `db:"learned_at"`
 	Quality        int       `db:"quality"`

--- a/backend/internal/learning/repository.go
+++ b/backend/internal/learning/repository.go
@@ -85,10 +85,16 @@ func NewDBLearningRepository(db *sqlx.DB) *DBLearningRepository {
 	return &DBLearningRepository{db: db}
 }
 
+// selectLearningLogColumns lists the columns explicitly because note_id
+// and origin_id are both nullable since migration 017 — COALESCE both
+// to zero so the int64 fields scan cleanly (a plain SELECT * would fail
+// to scan a NULL into int64).
+const selectLearningLogColumns = `SELECT id, COALESCE(note_id, 0) AS note_id, COALESCE(origin_id, 0) AS origin_id, status, learned_at, quality, response_time_ms, quiz_type, interval_days, concept_key, easiness_factor, source_notebook_id, created_at, updated_at FROM learning_logs`
+
 // FindAll returns all learning logs.
 func (r *DBLearningRepository) FindAll(ctx context.Context) ([]LearningLog, error) {
 	var logs []LearningLog
-	if err := r.db.SelectContext(ctx, &logs, "SELECT * FROM learning_logs ORDER BY id"); err != nil {
+	if err := r.db.SelectContext(ctx, &logs, selectLearningLogColumns+" ORDER BY id"); err != nil {
 		return nil, fmt.Errorf("load all learning logs: %w", err)
 	}
 	return logs, nil
@@ -105,10 +111,17 @@ func (r *DBLearningRepository) Create(ctx context.Context, log *LearningLog) err
 		log.NoteID = noteID
 	}
 
-	query := `INSERT INTO learning_logs (note_id, status, learned_at, quality, response_time_ms, quiz_type, interval_days, source_notebook_id, concept_key)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	if log.NoteID == 0 && log.OriginID == 0 {
+		return fmt.Errorf("learning log requires NoteID or OriginID")
+	}
+
+	// NULLIF turns a zero ID into SQL NULL so exactly one of
+	// (note_id, origin_id) is set: vocab logs carry note_id, etymology
+	// origin logs carry origin_id.
+	query := `INSERT INTO learning_logs (note_id, origin_id, status, learned_at, quality, response_time_ms, quiz_type, interval_days, source_notebook_id, concept_key)
+		VALUES (NULLIF($1, 0::bigint), NULLIF($2, 0::bigint), $3, $4, $5, $6, $7, $8, $9, $10)`
 	_, err := r.db.ExecContext(ctx, query,
-		log.NoteID, log.Status, log.LearnedAt, log.Quality, log.ResponseTimeMs, log.QuizType, log.IntervalDays, log.SourceNotebookID, log.ConceptKey)
+		log.NoteID, log.OriginID, log.Status, log.LearnedAt, log.Quality, log.ResponseTimeMs, log.QuizType, log.IntervalDays, log.SourceNotebookID, log.ConceptKey)
 	if err != nil {
 		return fmt.Errorf("insert learning log: %w", err)
 	}
@@ -153,8 +166,18 @@ func (r *DBLearningRepository) BatchCreate(ctx context.Context, logs []*Learning
 		return nil
 	}
 
-	columns := []string{"note_id", "status", "learned_at", "quality", "response_time_ms", "quiz_type", "interval_days", "source_notebook_id", "concept_key"}
-	const chunkSize = 5000 // 5000 * 9 columns = 45000 placeholders, well under 65535
+	columns := []string{"note_id", "origin_id", "status", "learned_at", "quality", "response_time_ms", "quiz_type", "interval_days", "source_notebook_id", "concept_key"}
+	const chunkSize = 5000 // 5000 * 10 columns = 50000 placeholders, under 65535
+
+	// Multi-row VALUES can't use NULLIF per-cell, so overwrite a zero ID
+	// with a nil interface so the driver passes SQL NULL. Exactly one of
+	// note_id / origin_id ends up set per row.
+	nullableID := func(id int64) interface{} {
+		if id == 0 {
+			return nil
+		}
+		return id
+	}
 
 	return database.RunInTx(ctx, r.db, func(ctx context.Context, tx *sqlx.Tx) error {
 		for i := 0; i < len(logs); i += chunkSize {
@@ -167,7 +190,7 @@ func (r *DBLearningRepository) BatchCreate(ctx context.Context, logs []*Learning
 			query := database.BuildMultiRowInsert("learning_logs", columns, len(chunk))
 			var args []interface{}
 			for _, l := range chunk {
-				args = append(args, l.NoteID, l.Status, l.LearnedAt, l.Quality, l.ResponseTimeMs, l.QuizType, l.IntervalDays, l.SourceNotebookID, l.ConceptKey)
+				args = append(args, nullableID(l.NoteID), nullableID(l.OriginID), l.Status, l.LearnedAt, l.Quality, l.ResponseTimeMs, l.QuizType, l.IntervalDays, l.SourceNotebookID, l.ConceptKey)
 			}
 			if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 				return fmt.Errorf("insert learning logs: %w", err)

--- a/backend/internal/learning/repository_test.go
+++ b/backend/internal/learning/repository_test.go
@@ -29,14 +29,14 @@ func TestDBLearningRepository_FindAll(t *testing.T) {
 				}).
 					AddRow(1, 10, "understood", now, 4, 1500, "notebook", 7, "", now, now).
 					AddRow(2, 11, "misunderstood", now, 1, 3000, "freeform", 1, "", now, now)
-				mock.ExpectQuery("SELECT \\* FROM learning_logs ORDER BY id").WillReturnRows(rows)
+				mock.ExpectQuery("SELECT id, COALESCE\\(note_id, 0\\) AS note_id, COALESCE\\(origin_id, 0\\) AS origin_id").WillReturnRows(rows)
 			},
 			wantLen: 2,
 		},
 		{
 			name: "db error",
 			setupMock: func(mock sqlmock.Sqlmock) {
-				mock.ExpectQuery("SELECT \\* FROM learning_logs ORDER BY id").
+				mock.ExpectQuery("SELECT id, COALESCE\\(note_id, 0\\) AS note_id, COALESCE\\(origin_id, 0\\) AS origin_id").
 					WillReturnError(fmt.Errorf("connection refused"))
 			},
 			wantErr: true,
@@ -85,7 +85,7 @@ func TestDBLearningRepository_Create(t *testing.T) {
 			log:  &LearningLog{NoteID: 10, Status: "understood", LearnedAt: now, Quality: 4, ResponseTimeMs: 1500, QuizType: "notebook", IntervalDays: 7, SourceNotebookID: "nb-1"},
 			setupMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectExec("INSERT INTO learning_logs").
-					WithArgs(int64(10), "understood", now, 4, 1500, "notebook", 7, "nb-1", "").
+					WithArgs(int64(10), int64(0), "understood", now, 4, 1500, "notebook", 7, "nb-1", "").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 		},
@@ -114,7 +114,7 @@ func TestDBLearningRepository_Create(t *testing.T) {
 					WithArgs("serendipity", "serendipity", "").
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(61)))
 				mock.ExpectExec("INSERT INTO learning_logs").
-					WithArgs(int64(61), "understood", now, 4, 1500, "notebook", 7, "nb-1", "").
+					WithArgs(int64(61), int64(0), "understood", now, 4, 1500, "notebook", 7, "nb-1", "").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 		},
@@ -138,7 +138,7 @@ func TestDBLearningRepository_Create(t *testing.T) {
 					WithArgs("cardiology", "cardiology", "").
 					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(42)))
 				mock.ExpectExec("INSERT INTO learning_logs").
-					WithArgs(int64(42), "misunderstood", now, 1, 3000, "notebook", 1, "wpme", "").
+					WithArgs(int64(42), int64(0), "misunderstood", now, 1, 3000, "notebook", 1, "wpme", "").
 					WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 		},
@@ -183,10 +183,10 @@ func TestDBLearningRepository_BatchCreate(t *testing.T) {
 			},
 			setupMock: func(mock sqlmock.Sqlmock) {
 				mock.ExpectBegin()
-				mock.ExpectExec("INSERT INTO learning_logs \\(note_id, status, learned_at, quality, response_time_ms, quiz_type, interval_days, source_notebook_id, concept_key\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9\\), \\(\\$10, \\$11, \\$12, \\$13, \\$14, \\$15, \\$16, \\$17, \\$18\\)").
+				mock.ExpectExec("INSERT INTO learning_logs \\(note_id, origin_id, status, learned_at, quality, response_time_ms, quiz_type, interval_days, source_notebook_id, concept_key\\) VALUES \\(\\$1, \\$2, \\$3, \\$4, \\$5, \\$6, \\$7, \\$8, \\$9, \\$10\\), \\(\\$11, \\$12, \\$13, \\$14, \\$15, \\$16, \\$17, \\$18, \\$19, \\$20\\)").
 					WithArgs(
-						int64(10), "understood", now, 4, 1500, "notebook", 7, "nb-1", "",
-						int64(11), "misunderstood", now, 1, 3000, "freeform", 1, "nb-2", "",
+						int64(10), nil, "understood", now, 4, 1500, "notebook", 7, "nb-1", "",
+						int64(11), nil, "misunderstood", now, 1, 3000, "freeform", 1, "nb-2", "",
 					).
 					WillReturnResult(sqlmock.NewResult(1, 2))
 				mock.ExpectCommit()

--- a/backend/internal/learning/yaml_repository.go
+++ b/backend/internal/learning/yaml_repository.go
@@ -60,19 +60,27 @@ func (r *YAMLLearningRepository) FindByNotebookID(notebookID string) ([]notebook
 }
 
 // WriteAll converts learning logs to LearningHistory YAML files grouped by notebook.
-func (r *YAMLLearningRepository) WriteAll(notes []notebook.NoteRecord, logs []LearningLog) error {
+func (r *YAMLLearningRepository) WriteAll(notes []notebook.NoteRecord, logs []LearningLog, origins []notebook.EtymologyOriginRecord) error {
 	noteByID := make(map[int64]*notebook.NoteRecord, len(notes))
 	for i := range notes {
 		noteByID[notes[i].ID] = &notes[i]
 	}
 
-	// Group logs by (noteID, sourceNotebookID)
+	// Group logs by (noteID, sourceNotebookID). Origin-typed logs
+	// (OriginID != 0) are split out and grouped by origin_id so they
+	// re-emerge as `type: origin` expressions rather than being
+	// attributed to a phantom note.
 	type noteNotebook struct {
 		noteID     int64
 		notebookID string
 	}
 	logsByNoteNotebook := make(map[noteNotebook][]LearningLog)
+	originLogsByID := make(map[int64][]LearningLog)
 	for _, log := range logs {
+		if log.OriginID > 0 {
+			originLogsByID[log.OriginID] = append(originLogsByID[log.OriginID], log)
+			continue
+		}
 		key := noteNotebook{log.NoteID, log.SourceNotebookID}
 		logsByNoteNotebook[key] = append(logsByNoteNotebook[key], log)
 	}
@@ -97,6 +105,17 @@ func (r *YAMLLearningRepository) WriteAll(notes []notebook.NoteRecord, logs []Le
 			if nn.NotebookType == "flashcard" {
 				info.isFlashcard = true
 			}
+		}
+	}
+
+	// Ensure every notebook that owns an origin is in the loop even if
+	// no vocab note in it touched a log.
+	originsByNotebook := make(map[string][]notebook.EtymologyOriginRecord)
+	for _, o := range origins {
+		originsByNotebook[o.NotebookID] = append(originsByNotebook[o.NotebookID], o)
+		if _, ok := notebookMap[o.NotebookID]; !ok {
+			notebookMap[o.NotebookID] = &notebookInfo{}
+			notebookIDs = append(notebookIDs, o.NotebookID)
 		}
 	}
 
@@ -129,6 +148,8 @@ func (r *YAMLLearningRepository) WriteAll(notes []notebook.NoteRecord, logs []Le
 		} else {
 			histories = r.buildStoryHistories(nbID, uniqueNoteIDs, noteByID, filteredLogs)
 		}
+
+		histories = appendOriginHistories(histories, nbID, originsByNotebook[nbID], originLogsByID)
 
 		if len(histories) == 0 {
 			continue
@@ -553,4 +574,77 @@ func (r *YAMLLearningRepository) BatchCreate(_ context.Context, _ []*LearningLog
 // targets the DB; YAML is the source of truth.
 func (r *YAMLLearningRepository) BatchDelete(_ context.Context, _ []int64) error {
 	return fmt.Errorf("BatchDelete is not supported for YAML learning repository")
+}
+
+// appendOriginHistories adds origin-typed LearningHistoryExpression
+// rows into the existing per-notebook histories. Each origin lands
+// under a LearningHistory block whose Title matches the origin's
+// session_title, mirroring the DBHistoryStore reconstructor so the
+// round-trip stays symmetric. Validate counts logs per expression
+// name regardless of scene structure.
+func appendOriginHistories(
+	histories []notebook.LearningHistory,
+	nbID string,
+	origins []notebook.EtymologyOriginRecord,
+	originLogsByID map[int64][]LearningLog,
+) []notebook.LearningHistory {
+	if len(origins) == 0 {
+		return histories
+	}
+
+	// Sort origins for deterministic output: by session_title, origin, sense.
+	sort.Slice(origins, func(i, j int) bool {
+		if origins[i].SessionTitle != origins[j].SessionTitle {
+			return origins[i].SessionTitle < origins[j].SessionTitle
+		}
+		if origins[i].Origin != origins[j].Origin {
+			return origins[i].Origin < origins[j].Origin
+		}
+		return origins[i].Sense < origins[j].Sense
+	})
+
+	historyIdxByTitle := make(map[string]int, len(histories))
+	for i := range histories {
+		historyIdxByTitle[histories[i].Metadata.Title] = i
+	}
+
+	for _, o := range origins {
+		expr := buildOriginExpression(o.Origin, originLogsByID[o.ID])
+		title := o.SessionTitle
+		idx, ok := historyIdxByTitle[title]
+		if !ok {
+			histories = append(histories, notebook.LearningHistory{
+				Metadata: notebook.LearningHistoryMetadata{NotebookID: nbID, Title: title},
+				Scenes: []notebook.LearningScene{{
+					Metadata:    notebook.LearningSceneMetadata{Title: title},
+					Expressions: []notebook.LearningHistoryExpression{expr},
+				}},
+			})
+			historyIdxByTitle[title] = len(histories) - 1
+			continue
+		}
+		sceneFound := false
+		for j := range histories[idx].Scenes {
+			if histories[idx].Scenes[j].Metadata.Title == title {
+				histories[idx].Scenes[j].Expressions = append(histories[idx].Scenes[j].Expressions, expr)
+				sceneFound = true
+				break
+			}
+		}
+		if !sceneFound {
+			histories[idx].Scenes = append(histories[idx].Scenes, notebook.LearningScene{
+				Metadata:    notebook.LearningSceneMetadata{Title: title},
+				Expressions: []notebook.LearningHistoryExpression{expr},
+			})
+		}
+	}
+	return histories
+}
+
+// buildOriginExpression mirrors buildExpression but tags the result as
+// type: origin. Logs flow into the same slots based on quiz_type.
+func buildOriginExpression(origin string, logs []LearningLog) notebook.LearningHistoryExpression {
+	expr := buildExpression(origin, logs)
+	expr.Type = notebook.LearningExpressionTypeOrigin
+	return expr
 }

--- a/backend/internal/learning/yaml_repository_test.go
+++ b/backend/internal/learning/yaml_repository_test.go
@@ -499,7 +499,7 @@ func TestYAMLLearningRepository_WriteAll(t *testing.T) {
 			outputDir := t.TempDir()
 			repo := NewYAMLLearningRepositoryWriter(outputDir)
 
-			err := repo.WriteAll(tt.notes, tt.logs)
+			err := repo.WriteAll(tt.notes, tt.logs, nil)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -534,7 +534,7 @@ func TestYAMLLearningRepository_WriteAll_errors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := NewYAMLLearningRepositoryWriter("/dev/null/invalid")
-			err := repo.WriteAll(tt.notes, tt.logs)
+			err := repo.WriteAll(tt.notes, tt.logs, nil)
 			assert.Error(t, err)
 		})
 	}
@@ -654,7 +654,7 @@ func TestYAMLLearningRepository_WriteAll_RoutesQuizTypesToCorrectSlots(t *testin
 
 	outputDir := t.TempDir()
 	repo := NewYAMLLearningRepositoryWriter(outputDir)
-	require.NoError(t, repo.WriteAll(notes, logs))
+	require.NoError(t, repo.WriteAll(notes, logs, nil))
 
 	var histories []notebook.LearningHistory
 	readYAMLHelper(t, filepath.Join(outputDir, "learning_notes", "demo.yml"), &histories)

--- a/backend/internal/mocks/datasync/mock_datasync.go
+++ b/backend/internal/mocks/datasync/mock_datasync.go
@@ -433,17 +433,17 @@ func (m *MockLearningSink) EXPECT() *MockLearningSinkMockRecorder {
 }
 
 // WriteAll mocks base method.
-func (m *MockLearningSink) WriteAll(notes []notebook.NoteRecord, logs []learning.LearningLog) error {
+func (m *MockLearningSink) WriteAll(notes []notebook.NoteRecord, logs []learning.LearningLog, origins []notebook.EtymologyOriginRecord) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteAll", notes, logs)
+	ret := m.ctrl.Call(m, "WriteAll", notes, logs, origins)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteAll indicates an expected call of WriteAll.
-func (mr *MockLearningSinkMockRecorder) WriteAll(notes, logs any) *gomock.Call {
+func (mr *MockLearningSinkMockRecorder) WriteAll(notes, logs, origins any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAll", reflect.TypeOf((*MockLearningSink)(nil).WriteAll), notes, logs)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAll", reflect.TypeOf((*MockLearningSink)(nil).WriteAll), notes, logs, origins)
 }
 
 // MockDictionarySink is a mock of DictionarySink interface.

--- a/backend/internal/notebook/definitions_repository.go
+++ b/backend/internal/notebook/definitions_repository.go
@@ -1,0 +1,159 @@
+package notebook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// DefinitionsSessionRecord mirrors a row of definitions_sessions. One row
+// per session in a definitions notebook.
+type DefinitionsSessionRecord struct {
+	ID           int64      `db:"id"`
+	NotebookID   string     `db:"notebook_id"`
+	Title        string     `db:"title"`
+	NotebookFile string     `db:"notebook_file"`
+	Date         *time.Time `db:"date"`
+	SortOrder    int        `db:"sort_order"`
+	CreatedAt    time.Time  `db:"created_at"`
+	UpdatedAt    time.Time  `db:"updated_at"`
+}
+
+// DefinitionsSceneRecord mirrors a row of definitions_scenes.
+type DefinitionsSceneRecord struct {
+	ID         int64     `db:"id"`
+	SessionID  int64     `db:"session_id"`
+	Title      string    `db:"title"`
+	SceneIndex int       `db:"scene_index"`
+	SortOrder  int       `db:"sort_order"`
+	CreatedAt  time.Time `db:"created_at"`
+	UpdatedAt  time.Time `db:"updated_at"`
+}
+
+// DefinitionsRepository owns the per-notebook session/scene structure
+// that used to live in definitions YAML. The notes themselves keep
+// living in `notes` + `notebook_notes` — only the structural metadata
+// (session titles, scene titles, ordering, dates) is in these tables.
+type DefinitionsRepository interface {
+	// ListSessions returns every session for a notebook, ordered by
+	// (date, sort_order, id) — same order the YAML reader produced.
+	ListSessions(ctx context.Context, notebookID string) ([]DefinitionsSessionRecord, error)
+	// ListScenes returns every scene for the given session IDs.
+	ListScenes(ctx context.Context, sessionIDs []int64) ([]DefinitionsSceneRecord, error)
+	// FindOrCreateSession returns the session matching
+	// (notebook_id, title, notebook_file), inserting one when missing.
+	// Called by RegisterDefinition so adding a definition through the UI
+	// can land in a brand-new session.
+	FindOrCreateSession(ctx context.Context, notebookID, title, notebookFile string, date *time.Time) (*DefinitionsSessionRecord, error)
+	// FindOrCreateScene returns the scene matching (session_id, scene_index),
+	// inserting one when missing. Scene titles are updated when the caller
+	// supplies a non-empty title and the existing row has an empty title.
+	FindOrCreateScene(ctx context.Context, sessionID int64, sceneIndex int, title string) (*DefinitionsSceneRecord, error)
+}
+
+// DBDefinitionsRepository is the PostgreSQL-backed implementation.
+type DBDefinitionsRepository struct {
+	db *sqlx.DB
+}
+
+// NewDBDefinitionsRepository constructs the repository.
+func NewDBDefinitionsRepository(db *sqlx.DB) *DBDefinitionsRepository {
+	return &DBDefinitionsRepository{db: db}
+}
+
+const definitionsSessionColumns = `id, notebook_id, title, notebook_file, "date", sort_order, created_at, updated_at`
+const definitionsSceneColumns = `id, session_id, title, scene_index, sort_order, created_at, updated_at`
+
+// ListSessions returns every session for notebookID.
+func (r *DBDefinitionsRepository) ListSessions(ctx context.Context, notebookID string) ([]DefinitionsSessionRecord, error) {
+	var rows []DefinitionsSessionRecord
+	query := `SELECT ` + definitionsSessionColumns + `
+		FROM definitions_sessions
+		WHERE notebook_id = $1
+		ORDER BY "date" NULLS LAST, sort_order, id`
+	if err := r.db.SelectContext(ctx, &rows, query, notebookID); err != nil {
+		return nil, fmt.Errorf("list definitions sessions: %w", err)
+	}
+	return rows, nil
+}
+
+// ListScenes returns every scene under the given session IDs.
+func (r *DBDefinitionsRepository) ListScenes(ctx context.Context, sessionIDs []int64) ([]DefinitionsSceneRecord, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+	query, args, err := sqlx.In(
+		`SELECT `+definitionsSceneColumns+`
+		 FROM definitions_scenes
+		 WHERE session_id IN (?)
+		 ORDER BY session_id, sort_order, scene_index, id`,
+		sessionIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build list definitions scenes: %w", err)
+	}
+	var rows []DefinitionsSceneRecord
+	if err := r.db.SelectContext(ctx, &rows, r.db.Rebind(query), args...); err != nil {
+		return nil, fmt.Errorf("list definitions scenes: %w", err)
+	}
+	return rows, nil
+}
+
+// FindOrCreateSession inserts when the (notebook_id, title, notebook_file)
+// tuple is missing and returns the resulting row either way.
+func (r *DBDefinitionsRepository) FindOrCreateSession(ctx context.Context, notebookID, title, notebookFile string, date *time.Time) (*DefinitionsSessionRecord, error) {
+	var session DefinitionsSessionRecord
+	err := r.db.GetContext(ctx, &session,
+		`SELECT `+definitionsSessionColumns+`
+		 FROM definitions_sessions
+		 WHERE notebook_id = $1 AND title = $2 AND notebook_file = $3`,
+		notebookID, title, notebookFile,
+	)
+	if err == nil {
+		return &session, nil
+	}
+
+	if err := r.db.GetContext(ctx, &session,
+		`INSERT INTO definitions_sessions (notebook_id, title, notebook_file, "date") VALUES ($1, $2, $3, $4)
+		 RETURNING `+definitionsSessionColumns,
+		notebookID, title, notebookFile, date,
+	); err != nil {
+		return nil, fmt.Errorf("insert definitions session: %w", err)
+	}
+	return &session, nil
+}
+
+// FindOrCreateScene inserts when (session_id, scene_index) is missing.
+// When the existing row has an empty title and the caller supplies one,
+// the title is filled in — saves a follow-up update path.
+func (r *DBDefinitionsRepository) FindOrCreateScene(ctx context.Context, sessionID int64, sceneIndex int, title string) (*DefinitionsSceneRecord, error) {
+	var scene DefinitionsSceneRecord
+	err := r.db.GetContext(ctx, &scene,
+		`SELECT `+definitionsSceneColumns+`
+		 FROM definitions_scenes
+		 WHERE session_id = $1 AND scene_index = $2`,
+		sessionID, sceneIndex,
+	)
+	if err == nil {
+		if scene.Title == "" && title != "" {
+			if _, uerr := r.db.ExecContext(ctx,
+				`UPDATE definitions_scenes SET title = $1 WHERE id = $2`, title, scene.ID,
+			); uerr != nil {
+				return nil, fmt.Errorf("update scene title: %w", uerr)
+			}
+			scene.Title = title
+		}
+		return &scene, nil
+	}
+
+	if err := r.db.GetContext(ctx, &scene,
+		`INSERT INTO definitions_scenes (session_id, title, scene_index) VALUES ($1, $2, $3)
+		 RETURNING `+definitionsSceneColumns,
+		sessionID, title, sceneIndex,
+	); err != nil {
+		return nil, fmt.Errorf("insert definitions scene: %w", err)
+	}
+	return &scene, nil
+}

--- a/backend/internal/notebook/flashcard_deck_repository.go
+++ b/backend/internal/notebook/flashcard_deck_repository.go
@@ -1,0 +1,86 @@
+package notebook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// FlashcardDeckRecord mirrors a row of flashcard_decks. Title matches
+// `notebook_notes.group` for the deck's cards, so joining the two yields
+// "all cards in this deck" without a separate junction table.
+type FlashcardDeckRecord struct {
+	ID          int64      `db:"id"`
+	NotebookID  string     `db:"notebook_id"`
+	Title       string     `db:"title"`
+	Description string     `db:"description"`
+	Date        *time.Time `db:"date"`
+	SortOrder   int        `db:"sort_order"`
+	CreatedAt   time.Time  `db:"created_at"`
+	UpdatedAt   time.Time  `db:"updated_at"`
+}
+
+// FlashcardDeckRepository owns flashcard deck metadata (title,
+// description, date) for a flashcard index. The cards themselves stay
+// in notes + notebook_notes.
+type FlashcardDeckRepository interface {
+	// ListByNotebook returns every deck for an index, ordered for stable
+	// rendering.
+	ListByNotebook(ctx context.Context, notebookID string) ([]FlashcardDeckRecord, error)
+	// FindOrCreate returns the deck matching (notebook_id, title),
+	// inserting one when missing.
+	FindOrCreate(ctx context.Context, notebookID, title, description string, date *time.Time) (*FlashcardDeckRecord, error)
+}
+
+// DBFlashcardDeckRepository is the PostgreSQL-backed implementation.
+type DBFlashcardDeckRepository struct {
+	db *sqlx.DB
+}
+
+// NewDBFlashcardDeckRepository constructs the repository.
+func NewDBFlashcardDeckRepository(db *sqlx.DB) *DBFlashcardDeckRepository {
+	return &DBFlashcardDeckRepository{db: db}
+}
+
+const flashcardDeckColumns = `id, notebook_id, title, description, "date", sort_order, created_at, updated_at`
+
+// ListByNotebook returns every deck for a notebook ordered by
+// (date, sort_order, id) so the rendering matches the YAML order.
+// PostgreSQL sorts NULLs last for ASC by default; NULLS LAST is
+// spelled out for clarity.
+func (r *DBFlashcardDeckRepository) ListByNotebook(ctx context.Context, notebookID string) ([]FlashcardDeckRecord, error) {
+	var rows []FlashcardDeckRecord
+	query := `SELECT ` + flashcardDeckColumns + `
+		FROM flashcard_decks
+		WHERE notebook_id = $1
+		ORDER BY "date" NULLS LAST, sort_order, id`
+	if err := r.db.SelectContext(ctx, &rows, query, notebookID); err != nil {
+		return nil, fmt.Errorf("list flashcard decks: %w", err)
+	}
+	return rows, nil
+}
+
+// FindOrCreate inserts when (notebook_id, title) is missing.
+func (r *DBFlashcardDeckRepository) FindOrCreate(ctx context.Context, notebookID, title, description string, date *time.Time) (*FlashcardDeckRecord, error) {
+	var deck FlashcardDeckRecord
+	err := r.db.GetContext(ctx, &deck,
+		`SELECT `+flashcardDeckColumns+`
+		 FROM flashcard_decks
+		 WHERE notebook_id = $1 AND title = $2`,
+		notebookID, title,
+	)
+	if err == nil {
+		return &deck, nil
+	}
+
+	if err := r.db.GetContext(ctx, &deck,
+		`INSERT INTO flashcard_decks (notebook_id, title, description, "date") VALUES ($1, $2, $3, $4)
+		 RETURNING `+flashcardDeckColumns,
+		notebookID, title, description, date,
+	); err != nil {
+		return nil, fmt.Errorf("insert flashcard deck: %w", err)
+	}
+	return &deck, nil
+}

--- a/backend/internal/notebook/skip_flag_repository.go
+++ b/backend/internal/notebook/skip_flag_repository.go
@@ -1,0 +1,144 @@
+package notebook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+// NoteSkipFlagRecord mirrors a row of note_skip_flags. Replaces the
+// SkippedAtMap that used to live on LearningHistoryExpression in YAML.
+type NoteSkipFlagRecord struct {
+	ID        int64     `db:"id"`
+	NoteID    int64     `db:"note_id"`
+	QuizType  string    `db:"quiz_type"`
+	SkippedAt time.Time `db:"skipped_at"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// OriginSkipFlagRecord mirrors a row of origin_skip_flags.
+type OriginSkipFlagRecord struct {
+	ID        int64     `db:"id"`
+	OriginID  int64     `db:"origin_id"`
+	QuizType  string    `db:"quiz_type"`
+	SkippedAt time.Time `db:"skipped_at"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// SkipFlagRepository owns per-quiz-type skip state for both vocabulary
+// notes and etymology origins. The YAML SkippedAtMap is gone; everything
+// flows through these tables.
+type SkipFlagRepository interface {
+	// FindNoteFlags returns every skip flag for the given note IDs.
+	FindNoteFlags(ctx context.Context, noteIDs []int64) ([]NoteSkipFlagRecord, error)
+	// FindOriginFlags returns every skip flag for the given origin IDs.
+	FindOriginFlags(ctx context.Context, originIDs []int64) ([]OriginSkipFlagRecord, error)
+	// SkipNote inserts or updates the skip flag for (note_id, quiz_type).
+	SkipNote(ctx context.Context, noteID int64, quizType string, at time.Time) error
+	// ResumeNote removes the skip flag for (note_id, quiz_type). No-op
+	// when the row doesn't exist.
+	ResumeNote(ctx context.Context, noteID int64, quizType string) error
+	// SkipOrigin / ResumeOrigin are the etymology equivalents.
+	SkipOrigin(ctx context.Context, originID int64, quizType string, at time.Time) error
+	ResumeOrigin(ctx context.Context, originID int64, quizType string) error
+}
+
+// DBSkipFlagRepository is the PostgreSQL-backed implementation.
+type DBSkipFlagRepository struct {
+	db *sqlx.DB
+}
+
+// NewDBSkipFlagRepository constructs the repository.
+func NewDBSkipFlagRepository(db *sqlx.DB) *DBSkipFlagRepository {
+	return &DBSkipFlagRepository{db: db}
+}
+
+// FindNoteFlags returns the skip rows for the given note IDs.
+func (r *DBSkipFlagRepository) FindNoteFlags(ctx context.Context, noteIDs []int64) ([]NoteSkipFlagRecord, error) {
+	if len(noteIDs) == 0 {
+		return nil, nil
+	}
+	query, args, err := sqlx.In(
+		`SELECT id, note_id, quiz_type, skipped_at, created_at, updated_at
+		 FROM note_skip_flags WHERE note_id IN (?)`,
+		noteIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build note skip flags query: %w", err)
+	}
+	var rows []NoteSkipFlagRecord
+	if err := r.db.SelectContext(ctx, &rows, r.db.Rebind(query), args...); err != nil {
+		return nil, fmt.Errorf("select note skip flags: %w", err)
+	}
+	return rows, nil
+}
+
+// FindOriginFlags returns the skip rows for the given origin IDs.
+func (r *DBSkipFlagRepository) FindOriginFlags(ctx context.Context, originIDs []int64) ([]OriginSkipFlagRecord, error) {
+	if len(originIDs) == 0 {
+		return nil, nil
+	}
+	query, args, err := sqlx.In(
+		`SELECT id, origin_id, quiz_type, skipped_at, created_at, updated_at
+		 FROM origin_skip_flags WHERE origin_id IN (?)`,
+		originIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build origin skip flags query: %w", err)
+	}
+	var rows []OriginSkipFlagRecord
+	if err := r.db.SelectContext(ctx, &rows, r.db.Rebind(query), args...); err != nil {
+		return nil, fmt.Errorf("select origin skip flags: %w", err)
+	}
+	return rows, nil
+}
+
+// SkipNote upserts the flag for (note_id, quiz_type).
+func (r *DBSkipFlagRepository) SkipNote(ctx context.Context, noteID int64, quizType string, at time.Time) error {
+	if _, err := r.db.ExecContext(ctx,
+		`INSERT INTO note_skip_flags (note_id, quiz_type, skipped_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (note_id, quiz_type) DO UPDATE SET skipped_at = EXCLUDED.skipped_at`,
+		noteID, quizType, at,
+	); err != nil {
+		return fmt.Errorf("upsert note skip flag: %w", err)
+	}
+	return nil
+}
+
+// ResumeNote drops the flag for (note_id, quiz_type).
+func (r *DBSkipFlagRepository) ResumeNote(ctx context.Context, noteID int64, quizType string) error {
+	if _, err := r.db.ExecContext(ctx,
+		`DELETE FROM note_skip_flags WHERE note_id = $1 AND quiz_type = $2`,
+		noteID, quizType,
+	); err != nil {
+		return fmt.Errorf("delete note skip flag: %w", err)
+	}
+	return nil
+}
+
+// SkipOrigin upserts the flag for (origin_id, quiz_type).
+func (r *DBSkipFlagRepository) SkipOrigin(ctx context.Context, originID int64, quizType string, at time.Time) error {
+	if _, err := r.db.ExecContext(ctx,
+		`INSERT INTO origin_skip_flags (origin_id, quiz_type, skipped_at) VALUES ($1, $2, $3)
+		 ON CONFLICT (origin_id, quiz_type) DO UPDATE SET skipped_at = EXCLUDED.skipped_at`,
+		originID, quizType, at,
+	); err != nil {
+		return fmt.Errorf("upsert origin skip flag: %w", err)
+	}
+	return nil
+}
+
+// ResumeOrigin drops the flag for (origin_id, quiz_type).
+func (r *DBSkipFlagRepository) ResumeOrigin(ctx context.Context, originID int64, quizType string) error {
+	if _, err := r.db.ExecContext(ctx,
+		`DELETE FROM origin_skip_flags WHERE origin_id = $1 AND quiz_type = $2`,
+		originID, quizType,
+	); err != nil {
+		return fmt.Errorf("delete origin skip flag: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/quiz/etymology.go
+++ b/backend/internal/quiz/etymology.go
@@ -685,7 +685,19 @@ func shouldIncludeOrigin(
 	if isOriginSkipped(histories, notebookTitle, sessionTitle, origin, quizType) {
 		return false
 	}
-	if findOriginExpression(histories, notebookTitle, sessionTitle, origin) == nil {
+	expr := findOriginExpression(histories, notebookTitle, sessionTitle, origin)
+	if expr == nil {
+		return includeUnstudied
+	}
+	// "Never seen in THIS mode" — the origin has history but no logs in
+	// the slot the requested mode reads from (etymology_breakdown for
+	// standard, etymology_assembly for reverse) — goes through the
+	// includeUnstudied gate, same as an origin with no history at all.
+	// Without this, an origin studied only in standard/freeform floods
+	// the reverse queue: needsOriginReview treats an empty same-mode
+	// slot as "due now", so every cross-mode-only origin appears in the
+	// reverse start-page count.
+	if len(expr.GetLogsForQuizType(quizType)) == 0 {
 		return includeUnstudied
 	}
 	return needsOriginReview(histories, notebookTitle, sessionTitle, origin, quizType)

--- a/backend/internal/quiz/etymology_test.go
+++ b/backend/internal/quiz/etymology_test.go
@@ -756,10 +756,17 @@ origins:
 			wantOrigins:      []string{"studied-due", "tried-failed", "never-seen-1", "never-seen-2"},
 		},
 		{
+			// tried-failed has logs only in etymology_breakdown_logs, not
+			// in etymology_assembly_logs. Per shouldIncludeOrigin's
+			// cross-mode gate, "no logs in the requested mode's slot"
+			// falls under includeUnstudied; with it off the reverse queue
+			// drops tried-failed. This is the fix that keeps the reverse
+			// start-page count from exploding when origins studied only in
+			// standard/freeform acquire history.
 			name:             "reverse, includeUnstudied=false",
 			includeUnstudied: false,
 			quizType:         notebook.QuizTypeEtymologyReverse,
-			wantOrigins:      []string{"studied-due", "tried-failed"},
+			wantOrigins:      []string{"studied-due"},
 		},
 		{
 			name:             "reverse, includeUnstudied=true",
@@ -805,4 +812,97 @@ origins:
 				"start page section count for the active mode must equal what the quiz loads")
 		})
 	}
+}
+
+// TestService_EtymologyReverseQueueCountsOnlyAssemblyHistory pins the
+// cross-mode gate in shouldIncludeOrigin: an origin studied only in a
+// different etymology mode (breakdown / freeform) must NOT flood the
+// reverse queue when includeUnstudied is off. Reproduces the start-page
+// count blow-up reported after sync-db routed origin logs onto
+// etymology_origins.id.
+func TestService_EtymologyReverseQueueCountsOnlyAssemblyHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	etymDir := filepath.Join(tmpDir, "etymology", "demo-roots")
+	require.NoError(t, os.MkdirAll(etymDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(etymDir, "index.yml"), []byte(`id: demo-roots
+kind: Etymology
+name: Demo Roots
+notebooks:
+  - ./origins.yml
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(etymDir, "origins.yml"), []byte(`metadata:
+  title: "Demo Lesson"
+origins:
+  - origin: reverse-studied
+    type: root
+    language: Latin
+    meaning: drilled in reverse before (assembly logs present)
+  - origin: only-breakdown
+    type: root
+    language: Latin
+    meaning: drilled in standard only, never in reverse
+`), 0o644))
+
+	today := time.Now().Format("2006-01-02")
+	learningDir := filepath.Join(tmpDir, "learning")
+	require.NoError(t, os.MkdirAll(learningDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "demo-roots.yml"), []byte(`- metadata:
+    notebook_id: demo-roots
+    title: Demo Roots
+  scenes:
+    - metadata:
+        title: "Demo Lesson"
+      expressions:
+        - expression: reverse-studied
+          etymology_assembly_logs:
+            - status: understood
+              learned_at: "2024-01-01"
+              quality: 4
+              interval_days: 7
+              quiz_type: etymology_assembly
+        - expression: only-breakdown
+          etymology_breakdown_logs:
+            - status: understood
+              learned_at: "`+today+`"
+              quality: 4
+              interval_days: 90
+              quiz_type: etymology_breakdown
+`), 0o644))
+
+	svc := NewService(
+		config.NotebooksConfig{
+			EtymologyDirectories:   []string{filepath.Join(tmpDir, "etymology")},
+			LearningNotesDirectory: learningDir,
+		},
+		nil, nil, nil,
+		config.QuizConfig{DisableShuffle: true},
+	)
+
+	t.Run("reverse includeUnstudied=false counts only assembly-history origins", func(t *testing.T) {
+		cards, err := svc.LoadEtymologyOriginCards(
+			[]string{"demo-roots"}, false, false, notebook.QuizTypeEtymologyReverse, nil,
+		)
+		require.NoError(t, err)
+		var got []string
+		for _, c := range cards {
+			got = append(got, c.Origin)
+		}
+		sort.Strings(got)
+		assert.Equal(t, []string{"reverse-studied"}, got,
+			"reverse queue with includeUnstudied=false must exclude origins whose "+
+				"history exists only in other etymology modes")
+	})
+
+	t.Run("reverse includeUnstudied=true counts everything", func(t *testing.T) {
+		cards, err := svc.LoadEtymologyOriginCards(
+			[]string{"demo-roots"}, true, false, notebook.QuizTypeEtymologyReverse, nil,
+		)
+		require.NoError(t, err)
+		var got []string
+		for _, c := range cards {
+			got = append(got, c.Origin)
+		}
+		sort.Strings(got)
+		assert.Equal(t, []string{"only-breakdown", "reverse-studied"}, got)
+	})
 }

--- a/backend/schemas/migrations/017_db_only_state.down.sql
+++ b/backend/schemas/migrations/017_db_only_state.down.sql
@@ -1,0 +1,12 @@
+-- Reverse 017_db_only_state. Drop the dependents on learning_logs
+-- before the tables the origin FK references.
+DROP INDEX IF EXISTS idx_learning_logs_origin_id;
+ALTER TABLE learning_logs DROP CONSTRAINT IF EXISTS fk_learning_logs_origin_id;
+ALTER TABLE learning_logs DROP COLUMN IF EXISTS origin_id;
+ALTER TABLE learning_logs ALTER COLUMN note_id SET NOT NULL;
+
+DROP TABLE IF EXISTS origin_skip_flags;
+DROP TABLE IF EXISTS note_skip_flags;
+DROP TABLE IF EXISTS flashcard_decks;
+DROP TABLE IF EXISTS definitions_scenes;
+DROP TABLE IF EXISTS definitions_sessions;

--- a/backend/schemas/migrations/017_db_only_state.up.sql
+++ b/backend/schemas/migrations/017_db_only_state.up.sql
@@ -1,0 +1,114 @@
+-- DB-only state tables. The runtime stops reading and writing learning
+-- history, definition session/scene structure, flashcard deck metadata,
+-- per-quiz-type skip flags, and etymology quiz logs from YAML. Story,
+-- ebook, and etymology-reference-notebook YAML stays read-only.
+--
+-- PostgreSQL port of the original MySQL migration: BIGSERIAL for
+-- auto-increment, per-table set_updated_at() triggers (there is no
+-- ON UPDATE CURRENT_TIMESTAMP column attribute), and plain UNIQUE
+-- constraints on TEXT columns (real session/scene/deck titles are
+-- short; Postgres indexes the full value with no prefix dance).
+
+-- definitions_sessions: replaces the YAML Definitions.Metadata block.
+-- One row per session in a definitions notebook (e.g. "Session 13:
+-- graphein"). date drives the notebook-detail sort order; sort_order
+-- preserves the YAML's original ordering for ties. title and
+-- notebook_file are TEXT because real definitions YAML carries lesson
+-- headings past the VARCHAR(255) cap.
+CREATE TABLE definitions_sessions (
+    id BIGSERIAL PRIMARY KEY,
+    notebook_id VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
+    notebook_file TEXT NOT NULL DEFAULT '',
+    "date" TIMESTAMP NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (notebook_id, title, notebook_file)
+);
+CREATE INDEX idx_definitions_sessions_notebook_id ON definitions_sessions (notebook_id);
+CREATE TRIGGER definitions_sessions_set_updated_at BEFORE UPDATE ON definitions_sessions
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- definitions_scenes: replaces the YAML DefinitionsScene.Metadata block.
+-- One row per scene under a session. scene_index is the YAML field; it
+-- only has to be unique within one session.
+CREATE TABLE definitions_scenes (
+    id BIGSERIAL PRIMARY KEY,
+    session_id BIGINT NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    scene_index INT NOT NULL DEFAULT 0,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (session_id) REFERENCES definitions_sessions(id) ON DELETE CASCADE,
+    UNIQUE (session_id, scene_index)
+);
+CREATE INDEX idx_definitions_scenes_session_id ON definitions_scenes (session_id);
+CREATE TRIGGER definitions_scenes_set_updated_at BEFORE UPDATE ON definitions_scenes
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- flashcard_decks: replaces the YAML FlashcardNotebook outer struct.
+-- One row per flashcard deck within a flashcard index. The cards
+-- themselves are still stored as notes + notebook_notes(group=title).
+CREATE TABLE flashcard_decks (
+    id BIGSERIAL PRIMARY KEY,
+    notebook_id VARCHAR(255) NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL DEFAULT '',
+    "date" TIMESTAMP NULL,
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (notebook_id, title)
+);
+CREATE INDEX idx_flashcard_decks_notebook_id ON flashcard_decks (notebook_id);
+CREATE TRIGGER flashcard_decks_set_updated_at BEFORE UPDATE ON flashcard_decks
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- note_skip_flags: replaces the YAML SkippedAtMap on
+-- LearningHistoryExpression. One row per (note, quiz_type) the user has
+-- excluded. quiz_type is the same string set used in learning_logs.
+CREATE TABLE note_skip_flags (
+    id BIGSERIAL PRIMARY KEY,
+    note_id BIGINT NOT NULL,
+    quiz_type VARCHAR(50) NOT NULL,
+    skipped_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (note_id) REFERENCES notes(id) ON DELETE CASCADE,
+    UNIQUE (note_id, quiz_type)
+);
+CREATE INDEX idx_note_skip_flags_note_id ON note_skip_flags (note_id);
+CREATE TRIGGER note_skip_flags_set_updated_at BEFORE UPDATE ON note_skip_flags
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- origin_skip_flags: same role as note_skip_flags but for etymology
+-- origins. Etymology quizzes target origins, not notes, so they need
+-- their own skip table; keeping them separate keeps note_skip_flags
+-- queries note-only.
+CREATE TABLE origin_skip_flags (
+    id BIGSERIAL PRIMARY KEY,
+    origin_id BIGINT NOT NULL,
+    quiz_type VARCHAR(50) NOT NULL,
+    skipped_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (origin_id) REFERENCES etymology_origins(id) ON DELETE CASCADE,
+    UNIQUE (origin_id, quiz_type)
+);
+CREATE INDEX idx_origin_skip_flags_origin_id ON origin_skip_flags (origin_id);
+CREATE TRIGGER origin_skip_flags_set_updated_at BEFORE UPDATE ON origin_skip_flags
+    FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- learning_logs extension: etymology quizzes target origins, not notes,
+-- so note_id must become nullable and origin_id needs to exist. Exactly
+-- one of the two is set per row. source_notebook_id already carries the
+-- etymology notebook ID; the new origin_id column lets analytics filter
+-- etymology logs directly without joining notes.
+ALTER TABLE learning_logs ALTER COLUMN note_id DROP NOT NULL;
+ALTER TABLE learning_logs ADD COLUMN origin_id BIGINT NULL;
+ALTER TABLE learning_logs
+    ADD CONSTRAINT fk_learning_logs_origin_id
+    FOREIGN KEY (origin_id) REFERENCES etymology_origins(id) ON DELETE CASCADE;
+CREATE INDEX idx_learning_logs_origin_id ON learning_logs (origin_id);


### PR DESCRIPTION
## Summary

Cuts the runtime over to MySQL as the single source of truth for everything the user generates (vocabulary notes, learning logs, skip flags, definitions / flashcard structure, dictionary cache). YAML stays read-only as the shared content library (stories, ebook chapters, etymology reference notebooks).

Before this PR, the server dual-wrote to YAML and DB, and writes silently disagreed. Per the discussion, **state** (definitions, flashcards, learning logs, skip flags) is what each user wants to learn — it belongs in DB. Stories / ebooks / etymology references are shared content and stay on disk.

## What changed

### Schema (migration 016)
- New tables: `definitions_sessions`, `definitions_scenes`, `flashcard_decks`, `note_skip_flags`, `origin_skip_flags`
- `learning_logs.note_id` becomes nullable; new `origin_id` column lets etymology quiz logs share the same table as vocab logs

### Runtime cutover
- `quiz.Service` and `server.NotebookHandler` read learning histories through a `learning.HistoryStore` seam — when wired (the runtime path), `LoadAll` builds the same `LearningHistory` shape from notes + learning_logs + skip flags + etymology origins
- `SaveEtymologyOriginResult` writes through `LearningRepository.Create` with `OriginID` set; the YAML write is gone
- `SkipWord` / `ResumeWord` upsert / delete rows in `note_skip_flags`
- `RegisterDefinition` / `DeleteDefinition` write to DB only; `definitions_sessions` / `_scenes` are upserted alongside
- Dictionary cache hydrates from `dictionary_entries` at startup; no more filesystem scan
- `Multi*Repository` wrappers + `YAMLLearningRepository` runtime wiring are gone; analytics is `DBRepository` only
- Bootstrap errors out at startup when the database isn't configured
- `analytics.DBRepository` now calls `metadataResolver.Resolve` so `NotebookKind` is populated for etymology rows on the Day Detail page

### Migration tool
- `langner migrate import-db` gains a second phase: `datasync.StateSeeder` reads the existing YAML once and idempotently seeds the new tables (sessions/scenes, flashcard decks, skip flags, etymology logs). Run it once before deploying the new server binary.

## CI status

- Backend Lint ✅
- Backend Test ✅
- Frontend Lint ✅
- Frontend Test ✅
- Validate example configurations (CI end-to-end: schema migrate + import + validate-db round-trip) ✅
- Frontend E2E ❌ — 19/31 passing (was 12/31 before this PR's fixes). The remaining 12 failing tests fall into three buckets:
  - **Standard vocabulary quiz on flashcards (7 tests)**: cards don't render the heading on `/quiz/standard`. Local backend tests for `LoadCards` / `FilterFlashcardNotebooks` all pass; the divergence between local fixture and e2e MySQL data path needs in-flight debugging that I can't do without the e2e DB stack running locally.
  - **Vocab freeform `Submit one freeform answer and finish` (1 test)**: 1-minute timeout — likely the same `LoadCards` issue under freeform mode.
  - **`Day Detail surfaces etymology results, not just vocabulary` (1 test)**: `scribo` text not visible on the analytics day detail page. Etymology logs flow through `learning_logs` via the legacy phantom-note path with `note_id` set; analytics DB query joins `learning_logs` with `notes` and renders rows correctly when the row matches the day filter, but I haven't been able to confirm whether the row is being filtered out by `WHERE status = 'misunderstood'` or by a missing notebook_notes join.
  - **Etymology Standard / Reverse mode quizzes (3 tests)**: similar to the standard quiz issue but on etymology origins.

The earlier-failing tests that this PR's fixes addressed: Etymology Freeform / Etymology Reverse BatchFeedback / Etymology Standard BatchFeedback / Filter Idioms words by Understood — all green now.

## What stayed on YAML (intentional)
- Story notebooks, ebook chapters, etymology reference notebooks — these are the shared content library, not state
- The notebook detail page still calls `reader.GetDefinitionsBook` for the definitions structure when rendering; the DB definitions tables are populated by `migrate import-db` but the runtime read path hasn't been swapped to read from them yet. For NEW definitions added through the web UI, this means they land in DB but won't appear in the UI until the YAML is regenerated — see follow-up task list

## Follow-ups not in this PR
- Fix the remaining 12 Frontend E2E test failures (vocab Standard quiz card rendering, etymology analytics row visibility, etymology Standard / Reverse quiz)
- Switch the notebook handler's definitions / flashcard structure read path to the new DB repos so freshly registered definitions show up without a YAML round-trip
- Drop `YAMLLearningRepository.Create` / `BatchCreate` once the interactive CLI quiz commands are either removed or modernised
- Thread `context.Context` through the `quiz.Service` methods that currently use `context.Background()` inside `loadHistories()`

## Test plan
- [x] `make test-coverage` (backend) — green
- [x] `langner migrate import-db --config config.example.yml` against a fresh MySQL — state tables populated
- [x] `langner migrate validate-db` against the populated DB — round-trip passes
- [ ] Start `langner-server` against the populated DB → web UI loads, skip / resume / etymology quiz writes persist across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)