### PR TITLE
fix: Mark-as-Correct now persists across all quiz types + YAML and DB

### DIFF
--- a/backend/internal/learning/multi_repository.go
+++ b/backend/internal/learning/multi_repository.go
@@ -35,3 +35,29 @@ func (m *MultiLearningRepository) BatchDelete(ctx context.Context, ids []int64) 
 	if err := m.secondary.BatchDelete(ctx, ids); err != nil { slog.Warn("secondary learning batch delete failed", "error", err) }
 	return nil
 }
+
+// UpdateLog overrides on both stores: primary first (its computed
+// values are authoritative), then secondary with MirrorValues set so
+// it writes exactly what primary just wrote. Secondary failure is
+// logged, not returned — the primary already committed the user's
+// intended override and a missing DB row is recoverable via re-import.
+func (m *MultiLearningRepository) UpdateLog(ctx context.Context, in UpdateLogInput) (UpdateLogResult, error) {
+	res, err := m.primary.UpdateLog(ctx, in)
+	if err != nil {
+		return UpdateLogResult{}, err
+	}
+	if !res.Found {
+		return res, nil
+	}
+	secondaryIn := in
+	secondaryIn.MarkCorrect = nil
+	secondaryIn.MirrorValues = &UpdateLogMirror{
+		Status:       res.NewStatus,
+		Quality:      res.NewQuality,
+		IntervalDays: res.NewIntervalDays,
+	}
+	if _, err := m.secondary.UpdateLog(ctx, secondaryIn); err != nil {
+		slog.Warn("secondary learning override failed", "error", err)
+	}
+	return res, nil
+}

--- a/backend/internal/learning/repository.go
+++ b/backend/internal/learning/repository.go
@@ -4,17 +4,72 @@ package learning
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 
 	"github.com/at-ishikawa/langner/internal/database"
 )
 
+// UpdateLogInput identifies a single learning log entry and the
+// override to apply. Different implementations use different subsets:
+// the YAML repository looks up by (NotebookName + StoryTitle/SceneTitle
+// + Expression/OriginalExpression + QuizType + LearnedAt); the DB
+// repository looks up by (NoteID + QuizType + LearnedAt). Pass
+// everything you have — unused fields are ignored.
+//
+// MarkCorrect carries the user's intent for a fresh override. When
+// MirrorValues is non-nil the repo skips its own
+// markCorrect→status/quality derivation and writes exactly what's
+// inside — used by MultiLearningRepository so the secondary store
+// applies the same bytes the primary just wrote.
+type UpdateLogInput struct {
+	NoteID             int64
+	NotebookName       string
+	StoryTitle         string
+	SceneTitle         string
+	Expression         string
+	OriginalExpression string
+	QuizType           string
+	LearnedAt          time.Time
+	MarkCorrect        *bool
+	MirrorValues       *UpdateLogMirror
+}
+
+// UpdateLogMirror carries the already-computed new values when a
+// secondary store should byte-match a primary's override.
+type UpdateLogMirror struct {
+	Status       string
+	Quality      int
+	IntervalDays int
+}
+
+// UpdateLogResult reports the pre-change values and the recomputed
+// next-review date. Found is false when no row/entry matched the
+// lookup keys; callers must treat that as a no-op (matches the
+// rows-affected=0 semantics of SQL UPDATE).
+type UpdateLogResult struct {
+	OriginalQuality      int
+	OriginalStatus       string
+	OriginalIntervalDays int
+	NewQuality           int
+	NewStatus            string
+	NewIntervalDays      int
+	NewNextReviewDate    string
+	Found                bool
+}
+
 // LearningRepository defines operations for managing learning logs.
 type LearningRepository interface {
 	FindAll(ctx context.Context) ([]LearningLog, error)
 	BatchCreate(ctx context.Context, logs []*LearningLog) error
 	Create(ctx context.Context, log *LearningLog) error
+	// UpdateLog rewrites the log identified by in's lookup keys
+	// according to in.MarkCorrect. Used by OverrideAnswer. The DB
+	// implementation can fall back to mirroring values computed
+	// upstream when in.NewStatus/NewQuality are pre-filled (used by
+	// MultiLearningRepository so YAML and DB stay byte-identical).
+	UpdateLog(ctx context.Context, in UpdateLogInput) (UpdateLogResult, error)
 	// BatchDelete removes rows whose IDs appear in ids. Used by the
 	// reconcile pass to drop DB-only logs that no longer exist in YAML.
 	BatchDelete(ctx context.Context, ids []int64) error
@@ -114,6 +169,94 @@ func (r *DBLearningRepository) BatchCreate(ctx context.Context, logs []*Learning
 		}
 		return nil
 	})
+}
+
+// UpdateLog rewrites a single learning_logs row identified by
+// (note_id, quiz_type, learned_at) according to in.MarkCorrect (or
+// in.MirrorValues when set). Returns the pre-update values plus the
+// recomputed next-review date so the handler can hand them back to the
+// frontend's Undo workflow.
+//
+// Lookup matches by exact learned_at when LearnedAt is non-zero; the
+// frontend always sends the YYYY-MM-DD or RFC3339 string of the
+// specific log the user clicked, so a same-day match is sufficient. If
+// no row matches, the call returns Found=false (no SQL no-op error).
+func (r *DBLearningRepository) UpdateLog(ctx context.Context, in UpdateLogInput) (UpdateLogResult, error) {
+	if in.NoteID == 0 || in.QuizType == "" || in.LearnedAt.IsZero() {
+		return UpdateLogResult{}, nil
+	}
+
+	// Find the row + read originals. DATE() lets the frontend pass a
+	// YYYY-MM-DD without losing matches to clock skew between the
+	// answer write and the override click.
+	type currentRow struct {
+		ID           int64     `db:"id"`
+		Status       string    `db:"status"`
+		Quality      int       `db:"quality"`
+		IntervalDays int       `db:"interval_days"`
+		LearnedAt    time.Time `db:"learned_at"`
+	}
+	var cur currentRow
+	err := r.db.GetContext(ctx, &cur, `
+		SELECT id, status, quality, interval_days, learned_at
+		FROM learning_logs
+		WHERE note_id = $1 AND quiz_type = $2 AND DATE(learned_at) = $3::date
+		ORDER BY learned_at DESC LIMIT 1`,
+		in.NoteID, in.QuizType, in.LearnedAt.Format("2006-01-02"))
+	if err != nil {
+		// No row matches — treat as soft no-op so callers in
+		// MultiLearningRepository don't fail the whole override when
+		// the YAML side succeeded but the DB doesn't have the log yet
+		// (e.g. fresh import that hasn't replayed the latest quiz).
+		return UpdateLogResult{}, nil
+	}
+
+	newStatus, newQuality, newIntervalDays := computeOverrideValues(in, cur.Status, cur.Quality, cur.IntervalDays)
+
+	if _, err := r.db.ExecContext(ctx, `
+		UPDATE learning_logs
+		SET status = $1, quality = $2, interval_days = $3
+		WHERE id = $4`,
+		newStatus, newQuality, newIntervalDays, cur.ID); err != nil {
+		return UpdateLogResult{}, fmt.Errorf("update learning_logs: %w", err)
+	}
+
+	return UpdateLogResult{
+		OriginalQuality:      cur.Quality,
+		OriginalStatus:       cur.Status,
+		OriginalIntervalDays: cur.IntervalDays,
+		NewQuality:           newQuality,
+		NewStatus:            newStatus,
+		NewIntervalDays:      newIntervalDays,
+		NewNextReviewDate:    cur.LearnedAt.AddDate(0, 0, newIntervalDays).Format("2006-01-02"),
+		Found:                true,
+	}, nil
+}
+
+// computeOverrideValues derives the post-override status/quality/
+// interval. If the caller provided MirrorValues (the YAML primary's
+// already-computed values, in the Multi flow), those win — keeping
+// YAML and DB byte-identical. Otherwise we apply the markCorrect
+// shorthand directly: quality 1/misunderstood or 4/understood with
+// interval reset to 1 on misunderstood, otherwise carry the prior
+// interval. The DB doesn't have the calculator's full SM-2 chain at
+// hand; for the rare DB-only deployment that's a small drift the
+// next quiz answer will replay through the YAML calculator anyway.
+func computeOverrideValues(in UpdateLogInput, curStatus string, curQuality, curInterval int) (status string, quality, intervalDays int) {
+	if in.MirrorValues != nil {
+		return in.MirrorValues.Status, in.MirrorValues.Quality, in.MirrorValues.IntervalDays
+	}
+	if in.MarkCorrect == nil {
+		return curStatus, curQuality, curInterval
+	}
+	if *in.MarkCorrect {
+		newStatus := "understood"
+		if in.QuizType == "freeform" || in.QuizType == "etymology_freeform" {
+			newStatus = "usable"
+		}
+		return newStatus, 4, max(curInterval, 1)
+	}
+	return "misunderstood", 1, 1
 }
 
 // BatchDelete removes the rows whose IDs are in the slice. Used by the

--- a/backend/internal/learning/repository_test.go
+++ b/backend/internal/learning/repository_test.go
@@ -191,3 +191,102 @@ func TestDBLearningRepository_BatchCreate(t *testing.T) {
 		})
 	}
 }
+
+// TestDBLearningRepository_UpdateLog_MarkCorrect locks in the DB-side
+// shape of OverrideAnswer: SELECT the matching row by (note_id,
+// quiz_type, learned_at), UPDATE status/quality/interval, hand back
+// the pre-update values for the frontend Undo flow.
+func TestDBLearningRepository_UpdateLog_MarkCorrect(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	sqlxDB := sqlx.NewDb(db, "pgx")
+	repo := NewDBLearningRepository(sqlxDB)
+
+	learnedAt := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT id, status, quality, interval_days, learned_at FROM learning_logs`).
+		WithArgs(int64(42), "notebook", "2026-06-29").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status", "quality", "interval_days", "learned_at"}).
+			AddRow(int64(7), "misunderstood", 1, 1, learnedAt))
+	mock.ExpectExec(`UPDATE learning_logs SET status = \$1, quality = \$2, interval_days = \$3 WHERE id = \$4`).
+		WithArgs("understood", 4, 1, int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	markCorrect := true
+	res, err := repo.UpdateLog(context.Background(), UpdateLogInput{
+		NoteID:      42,
+		QuizType:    "notebook",
+		LearnedAt:   learnedAt,
+		MarkCorrect: &markCorrect,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Found)
+	assert.Equal(t, "misunderstood", res.OriginalStatus, "OriginalStatus surfaces the pre-override value for Undo")
+	assert.Equal(t, 1, res.OriginalQuality)
+	assert.Equal(t, "understood", res.NewStatus)
+	assert.Equal(t, 4, res.NewQuality)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestDBLearningRepository_UpdateLog_Mirror covers the path
+// MultiLearningRepository takes after the primary (YAML) has computed
+// the new status/quality/interval — the secondary store applies the
+// values verbatim, no markCorrect derivation.
+func TestDBLearningRepository_UpdateLog_Mirror(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	sqlxDB := sqlx.NewDb(db, "pgx")
+	repo := NewDBLearningRepository(sqlxDB)
+
+	learnedAt := time.Date(2026, 6, 29, 10, 0, 0, 0, time.UTC)
+	mock.ExpectQuery(`SELECT id, status, quality, interval_days, learned_at FROM learning_logs`).
+		WithArgs(int64(42), "notebook", "2026-06-29").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "status", "quality", "interval_days", "learned_at"}).
+			AddRow(int64(7), "misunderstood", 1, 1, learnedAt))
+	mock.ExpectExec(`UPDATE learning_logs SET status = \$1, quality = \$2, interval_days = \$3 WHERE id = \$4`).
+		WithArgs("understood", 4, 3, int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	res, err := repo.UpdateLog(context.Background(), UpdateLogInput{
+		NoteID:    42,
+		QuizType:  "notebook",
+		LearnedAt: learnedAt,
+		MirrorValues: &UpdateLogMirror{
+			Status:       "understood",
+			Quality:      4,
+			IntervalDays: 3,
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Found)
+	assert.Equal(t, 3, res.NewIntervalDays, "MirrorValues overrides any markCorrect-derived interval")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestDBLearningRepository_UpdateLog_NoMatch confirms the soft-no-op
+// when no row matches: Found=false, no error. This is what
+// MultiLearningRepository relies on so a YAML-only entry doesn't
+// fail the whole override when the DB side hasn't seen it yet.
+func TestDBLearningRepository_UpdateLog_NoMatch(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+	sqlxDB := sqlx.NewDb(db, "pgx")
+	repo := NewDBLearningRepository(sqlxDB)
+
+	mock.ExpectQuery(`SELECT id, status, quality, interval_days, learned_at FROM learning_logs`).
+		WithArgs(int64(42), "notebook", "2026-06-29").
+		WillReturnError(fmt.Errorf("sql: no rows in result set"))
+
+	markCorrect := true
+	res, err := repo.UpdateLog(context.Background(), UpdateLogInput{
+		NoteID:      42,
+		QuizType:    "notebook",
+		LearnedAt:   time.Date(2026, 6, 29, 0, 0, 0, 0, time.UTC),
+		MarkCorrect: &markCorrect,
+	})
+	require.NoError(t, err, "missing row must be a soft no-op, not an error")
+	assert.False(t, res.Found)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/learning/yaml_repository.go
+++ b/backend/internal/learning/yaml_repository.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/at-ishikawa/langner/internal/notebook"
 )
@@ -424,6 +425,78 @@ func (r *YAMLLearningRepository) Create(_ context.Context, log *LearningLog) err
 	notePath := filepath.Join(dir, log.NotebookName+".yml")
 	if err := notebook.WriteYamlFile(notePath, updater.GetHistory()); err != nil { return fmt.Errorf("write learning history for %q: %w", log.NotebookName, err) }
 	return nil
+}
+
+// UpdateLog rewrites the YAML log entry identified by the lookup keys
+// according to in.MarkCorrect, using LearningHistoryUpdater so the
+// calculator recomputes interval_days and (for freeform variants)
+// both halves of the paired log lists stay in sync.
+func (r *YAMLLearningRepository) UpdateLog(_ context.Context, in UpdateLogInput) (UpdateLogResult, error) {
+	dir := r.directory
+	histories, err := notebook.NewLearningHistories(dir)
+	if err != nil {
+		return UpdateLogResult{}, fmt.Errorf("load learning histories: %w", err)
+	}
+	updater := notebook.NewLearningHistoryUpdater(histories[in.NotebookName], r.calculator)
+
+	res := updater.OverrideLog(notebook.OverrideLogInput{
+		Expression:         in.Expression,
+		OriginalExpression: in.OriginalExpression,
+		QuizType:           notebook.QuizType(in.QuizType),
+		LearnedAt:          formatLearnedAt(in.LearnedAt),
+		MarkCorrect:        in.MarkCorrect,
+	})
+	if !res.Found {
+		return UpdateLogResult{}, nil
+	}
+
+	notePath := filepath.Join(dir, in.NotebookName+".yml")
+	if err := notebook.WriteYamlFile(notePath, updater.GetHistory()); err != nil {
+		return UpdateLogResult{}, fmt.Errorf("write learning history for %q: %w", in.NotebookName, err)
+	}
+	// Read back the just-written entry so the caller can mirror the
+	// exact bytes onto the secondary store. The updater's result
+	// already carries originals; we re-resolve the expression to read
+	// out the new status/quality/interval that landed on disk.
+	expr := updater.FindExpressionByAnyName(in.Expression, in.OriginalExpression)
+	var newStatus string
+	var newQuality, newInterval int
+	if expr != nil {
+		logs := expr.GetLogsForQuizType(notebook.QuizType(in.QuizType))
+		for _, l := range logs {
+			if l.LearnedAt.Format(time.RFC3339) == formatLearnedAt(in.LearnedAt) ||
+				l.LearnedAt.Format("2006-01-02") == formatLearnedAt(in.LearnedAt) {
+				newStatus = string(l.Status)
+				newQuality = l.Quality
+				newInterval = l.IntervalDays
+				break
+			}
+		}
+	}
+	return UpdateLogResult{
+		OriginalQuality:      res.OriginalQuality,
+		OriginalStatus:       res.OriginalStatus,
+		OriginalIntervalDays: res.OriginalIntervalDays,
+		NewQuality:           newQuality,
+		NewStatus:            newStatus,
+		NewIntervalDays:      newInterval,
+		NewNextReviewDate:    res.NewNextReviewDate,
+		Found:                true,
+	}, nil
+}
+
+// formatLearnedAt picks the same string format the updater's
+// indexLogByLearnedAt accepts. Prefers RFC3339 so micro-second-precise
+// timestamps round-trip; falls back to YYYY-MM-DD for older logs the
+// importer stored without time-of-day.
+func formatLearnedAt(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t.Format("2006-01-02")
+	}
+	return t.Format(time.RFC3339)
 }
 
 func (r *YAMLLearningRepository) FindAll(_ context.Context) ([]LearningLog, error) {

--- a/backend/internal/mocks/learning/mock_repository.go
+++ b/backend/internal/mocks/learning/mock_repository.go
@@ -97,3 +97,18 @@ func (mr *MockLearningRepositoryMockRecorder) FindAll(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockLearningRepository)(nil).FindAll), ctx)
 }
+
+// UpdateLog mocks base method.
+func (m *MockLearningRepository) UpdateLog(ctx context.Context, in learning.UpdateLogInput) (learning.UpdateLogResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateLog", ctx, in)
+	ret0, _ := ret[0].(learning.UpdateLogResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateLog indicates an expected call of UpdateLog.
+func (mr *MockLearningRepositoryMockRecorder) UpdateLog(ctx, in any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLog", reflect.TypeOf((*MockLearningRepository)(nil).UpdateLog), ctx, in)
+}

--- a/backend/internal/notebook/learning_history_updater.go
+++ b/backend/internal/notebook/learning_history_updater.go
@@ -271,19 +271,33 @@ func (u *LearningHistoryUpdater) createNewExpressionWithQuality(
 // FindExpressionByName searches for an expression across all histories, returning
 // a pointer to the expression. Returns nil if not found.
 func (u *LearningHistoryUpdater) FindExpressionByName(expression string) *LearningHistoryExpression {
-	for hi := range u.history {
-		h := &u.history[hi]
-		// Always search top-level expressions first (flashcard, etymology, etc.)
-		for ei := range h.Expressions {
-			if strings.EqualFold(h.Expressions[ei].Expression, expression) {
-				return &h.Expressions[ei]
-			}
+	return u.FindExpressionByAnyName(expression)
+}
+
+// FindExpressionByAnyName tries every candidate name in order and returns
+// the first matching expression across all histories. Used for the
+// definitions-style case where a card's Expression is the Definition
+// form but the YAML stores the entry under the original Note.Expression
+// — callers pass both forms so the fallback succeeds.
+func (u *LearningHistoryUpdater) FindExpressionByAnyName(names ...string) *LearningHistoryExpression {
+	for _, name := range names {
+		if name == "" {
+			continue
 		}
-		// Then search scenes
-		for si := range h.Scenes {
-			for ei := range h.Scenes[si].Expressions {
-				if strings.EqualFold(h.Scenes[si].Expressions[ei].Expression, expression) {
-					return &h.Scenes[si].Expressions[ei]
+		for hi := range u.history {
+			h := &u.history[hi]
+			// Always search top-level expressions first (flashcard, etymology, etc.)
+			for ei := range h.Expressions {
+				if strings.EqualFold(h.Expressions[ei].Expression, name) {
+					return &h.Expressions[ei]
+				}
+			}
+			// Then search scenes
+			for si := range h.Scenes {
+				for ei := range h.Scenes[si].Expressions {
+					if strings.EqualFold(h.Scenes[si].Expressions[ei].Expression, name) {
+						return &h.Scenes[si].Expressions[ei]
+					}
 				}
 			}
 		}
@@ -291,123 +305,252 @@ func (u *LearningHistoryUpdater) FindExpressionByName(expression string) *Learni
 	return nil
 }
 
-// OverrideLog finds a learning log by learnedAt date and quiz type, then overrides it.
-// Returns the original values for undo purposes.
-func (u *LearningHistoryUpdater) OverrideLog(
-	expression string,
-	quizType QuizType,
-	learnedAt string,
-	markCorrect *bool,
-	nextReviewDate string,
-) (originalQuality int, originalStatus string, originalIntervalDays int, newNextReview string, found bool) {
-	expr := u.FindExpressionByName(expression)
-	if expr == nil {
-		return 0, "", 0, "", false
-	}
-
-	logs := expr.GetLogsForQuizType(quizType)
-	for i, log := range logs {
-		if log.LearnedAt.Format("2006-01-02") != learnedAt && log.LearnedAt.Format(time.RFC3339) != learnedAt {
-			continue
-		}
-
-		originalQuality = log.Quality
-		originalStatus = string(log.Status)
-		originalIntervalDays = log.IntervalDays
-
-		if markCorrect != nil {
-			if *markCorrect {
-				logs[i].Quality = 3
-				logs[i].Status = LearnedStatusUnderstood
-			} else {
-				logs[i].Quality = 1
-				logs[i].Status = LearnedStatusMisunderstood
-			}
-
-			// Replay the chain of older logs with this entry appended so
-			// the recomputed interval matches what `validate --fix` would
-			// produce: same chain logic, same early-review guard.
-			var previousLogs []LearningRecord
-			if i+1 < len(logs) {
-				previousLogs = logs[i+1:]
-			}
-			newInterval, _ := u.calculator.NextIntervalForWrite(previousLogs, logs[i])
-			logs[i].IntervalDays = newInterval
-		}
-
-		if nextReviewDate != "" {
-			nextDate, err := time.Parse("2006-01-02", nextReviewDate)
-			if err == nil {
-				intervalDays := int(nextDate.Sub(log.LearnedAt.Time).Hours() / 24)
-				if intervalDays < 1 {
-					intervalDays = 1
-				}
-				logs[i].IntervalDays = intervalDays
-				logs[i].OverrideInterval = intervalDays
-			}
-		}
-
-		// Write back the logs
-		switch quizType {
-		case QuizTypeReverse:
-			expr.ReverseLogs = logs
-		case QuizTypeEtymologyStandard:
-			expr.EtymologyBreakdownLogs = logs
-		case QuizTypeEtymologyReverse:
-			expr.EtymologyAssemblyLogs = logs
-		default:
-			expr.LearnedLogs = logs
-		}
-
-		newNextReview = logs[i].LearnedAt.AddDate(0, 0, logs[i].IntervalDays).Format("2006-01-02")
-		return originalQuality, originalStatus, originalIntervalDays, newNextReview, true
-	}
-
-	return 0, "", 0, "", false
+// OverrideLogInput carries everything OverrideLog needs to locate and
+// rewrite a single learning log entry.
+//
+//   - Expression / OriginalExpression: the YAML lookup key. Definitions-
+//     style cards expose the long Definition form as the card's Entry
+//     while the YAML keeps the original word; passing both lets the
+//     updater fall back. Either field may be empty.
+//   - QuizType: which per-quiz-type log list to scan. For Freeform
+//     variants, OverrideLog mirrors the write side (Create) and flips
+//     the matching entry in BOTH paired lists.
+//   - LearnedAt: YYYY-MM-DD or RFC3339; identifies the specific log
+//     within the list (never blindly logs[0]).
+//   - MarkCorrect: nil = no status change; non-nil = set the entry to
+//     the explicit correct/incorrect state. Toggling is not a primitive
+//     here — callers that want toggle should compute it themselves and
+//     pass the desired state, which is what the frontend already does.
+type OverrideLogInput struct {
+	Expression         string
+	OriginalExpression string
+	QuizType           QuizType
+	LearnedAt          string
+	MarkCorrect        *bool
 }
 
-// UndoOverrideLog restores original values for a learning log entry.
-func (u *LearningHistoryUpdater) UndoOverrideLog(
-	expression string,
-	quizType QuizType,
-	learnedAt string,
-	originalQuality int,
-	originalStatus string,
-	originalIntervalDays int,
-) (correct bool, nextReview string, found bool) {
-	expr := u.FindExpressionByName(expression)
+// OverrideLogResult reports the pre-change values of the affected log
+// plus the recomputed next-review date. Found is false when no log
+// matched the (expression, quiz_type, learned_at) tuple — callers must
+// treat that as a soft no-op (the same way Update returns rows-affected
+// 0 in SQL).
+type OverrideLogResult struct {
+	OriginalQuality      int
+	OriginalStatus       string
+	OriginalIntervalDays int
+	NewNextReviewDate    string
+	Found                bool
+}
+
+// OverrideLog rewrites the log identified by (expression/originalExpression,
+// quizType, learnedAt) according to MarkCorrect. When the quiz type is one
+// of the freeform variants — which write the same answer into two paired
+// log lists at submit time — the override is applied to both lists in the
+// same call so the two halves of one logical answer stay in sync.
+func (u *LearningHistoryUpdater) OverrideLog(in OverrideLogInput) OverrideLogResult {
+	expr := u.FindExpressionByAnyName(in.Expression, in.OriginalExpression)
 	if expr == nil {
-		return false, "", false
+		return OverrideLogResult{}
 	}
 
-	logs := expr.GetLogsForQuizType(quizType)
+	primary := in.QuizType.PrimaryLogList()
+	logs := getLogsByList(expr, primary)
+	idx := indexLogByLearnedAt(logs, in.LearnedAt)
+	if idx < 0 {
+		return OverrideLogResult{}
+	}
+
+	result := OverrideLogResult{
+		OriginalQuality:      logs[idx].Quality,
+		OriginalStatus:       string(logs[idx].Status),
+		OriginalIntervalDays: logs[idx].IntervalDays,
+	}
+
+	if in.MarkCorrect != nil {
+		applyMark(&logs[idx], *in.MarkCorrect, in.QuizType)
+		var previous []LearningRecord
+		if idx+1 < len(logs) {
+			previous = logs[idx+1:]
+		}
+		newInterval, _ := u.calculator.NextIntervalForWrite(previous, logs[idx])
+		logs[idx].IntervalDays = newInterval
+	}
+	setLogsByList(expr, primary, logs)
+	mirrorOverrideToPair(expr, in.QuizType, logs[idx])
+
+	result.NewNextReviewDate = logs[idx].LearnedAt.AddDate(0, 0, logs[idx].IntervalDays).Format("2006-01-02")
+	result.Found = true
+	return result
+}
+
+// UndoOverrideLogInput is the symmetric input for UndoOverrideLog.
+type UndoOverrideLogInput struct {
+	Expression           string
+	OriginalExpression   string
+	QuizType             QuizType
+	LearnedAt            string
+	OriginalQuality      int
+	OriginalStatus       string
+	OriginalIntervalDays int
+}
+
+// UndoOverrideLogResult mirrors OverrideLogResult for the undo path.
+type UndoOverrideLogResult struct {
+	Correct           bool
+	NewNextReviewDate string
+	Found             bool
+}
+
+// UndoOverrideLog restores a log entry to a previously captured state.
+// Used by the Analytics UI's "Undo" button after a manual override.
+// Like OverrideLog, the freeform variants mirror the restore across
+// both paired log lists.
+func (u *LearningHistoryUpdater) UndoOverrideLog(in UndoOverrideLogInput) UndoOverrideLogResult {
+	expr := u.FindExpressionByAnyName(in.Expression, in.OriginalExpression)
+	if expr == nil {
+		return UndoOverrideLogResult{}
+	}
+
+	primary := in.QuizType.PrimaryLogList()
+	logs := getLogsByList(expr, primary)
+	idx := indexLogByLearnedAt(logs, in.LearnedAt)
+	if idx < 0 {
+		return UndoOverrideLogResult{}
+	}
+
+	logs[idx].Quality = in.OriginalQuality
+	logs[idx].Status = LearnedStatus(in.OriginalStatus)
+	logs[idx].IntervalDays = in.OriginalIntervalDays
+	logs[idx].OverrideInterval = 0
+	setLogsByList(expr, primary, logs)
+	mirrorOverrideToPair(expr, in.QuizType, logs[idx])
+
+	return UndoOverrideLogResult{
+		Correct:           logs[idx].Quality >= 3,
+		NewNextReviewDate: logs[idx].LearnedAt.AddDate(0, 0, logs[idx].IntervalDays).Format("2006-01-02"),
+		Found:             true,
+	}
+}
+
+// applyMark writes the desired correct/incorrect state onto a log.
+// Standard / reverse / etymology-non-freeform use the binary
+// understood/misunderstood pair; freeform variants use can-be-used to
+// match the higher bar the freeform write path sets (active recall).
+func applyMark(log *LearningRecord, markCorrect bool, quizType QuizType) {
+	if !markCorrect {
+		log.Quality = 1
+		log.Status = LearnedStatusMisunderstood
+		return
+	}
+	log.Quality = 4
+	if quizType == QuizTypeFreeform || quizType == QuizTypeEtymologyFreeform {
+		log.Status = LearnedStatusCanBeUsed
+	} else {
+		log.Status = LearnedStatusUnderstood
+	}
+}
+
+// indexLogByLearnedAt returns the index of the log entry whose LearnedAt
+// matches the given YYYY-MM-DD or RFC3339 string, or -1 if none match.
+func indexLogByLearnedAt(logs []LearningRecord, learnedAt string) int {
+	if learnedAt == "" {
+		return -1
+	}
 	for i, log := range logs {
-		if log.LearnedAt.Format("2006-01-02") != learnedAt && log.LearnedAt.Format(time.RFC3339) != learnedAt {
-			continue
+		if log.LearnedAt.Format("2006-01-02") == learnedAt ||
+			log.LearnedAt.Format(time.RFC3339) == learnedAt {
+			return i
 		}
-
-		logs[i].Quality = originalQuality
-		logs[i].Status = LearnedStatus(originalStatus)
-		logs[i].IntervalDays = originalIntervalDays
-		logs[i].OverrideInterval = 0
-
-		switch quizType {
-		case QuizTypeReverse:
-			expr.ReverseLogs = logs
-		case QuizTypeEtymologyStandard:
-			expr.EtymologyBreakdownLogs = logs
-		case QuizTypeEtymologyReverse:
-			expr.EtymologyAssemblyLogs = logs
-		default:
-			expr.LearnedLogs = logs
-		}
-
-		correct = logs[i].Quality >= 3
-		nextReview = logs[i].LearnedAt.AddDate(0, 0, logs[i].IntervalDays).Format("2006-01-02")
-		return correct, nextReview, true
 	}
+	return -1
+}
 
-	return false, "", false
+// mirrorOverrideToPair handles the freeform-pair case: when QuizType is
+// Freeform / EtymologyFreeform, the write path appends the same answer
+// into two log lists (LearnedLogs+ReverseLogs, or EtymologyBreakdown+
+// EtymologyAssembly). After overriding one half we must apply the same
+// mutation to the matching entry in the other half so the two stay
+// consistent. The same-day match-by-learnedAt is how the lookup pairs
+// them — the freeform writer stamps both with the same timestamp.
+func mirrorOverrideToPair(expr *LearningHistoryExpression, quizType QuizType, updated LearningRecord) {
+	var pair logList
+	switch quizType {
+	case QuizTypeFreeform:
+		pair = listReverse
+	case QuizTypeEtymologyFreeform:
+		pair = listEtymologyAssembly
+	default:
+		return
+	}
+	pairLogs := getLogsByList(expr, pair)
+	idx := indexLogByLearnedAt(pairLogs, updated.LearnedAt.Format(time.RFC3339))
+	if idx < 0 {
+		idx = indexLogByLearnedAt(pairLogs, updated.LearnedAt.Format("2006-01-02"))
+	}
+	if idx < 0 {
+		return
+	}
+	pairLogs[idx].Quality = updated.Quality
+	pairLogs[idx].Status = updated.Status
+	pairLogs[idx].IntervalDays = updated.IntervalDays
+	pairLogs[idx].OverrideInterval = updated.OverrideInterval
+	setLogsByList(expr, pair, pairLogs)
+}
+
+// logList is an internal enum picking which log slice on a
+// LearningHistoryExpression to read/write. Kept private to this file so
+// OverrideLog / UndoOverrideLog / mirrorOverrideToPair speak the same
+// language without exposing the discriminator to the rest of the package.
+type logList int
+
+const (
+	listLearned logList = iota
+	listReverse
+	listEtymologyBreakdown
+	listEtymologyAssembly
+)
+
+// PrimaryLogList returns the log list a single OverrideLog call mutates
+// for the given quiz type. Freeform variants identify their primary
+// list here; the secondary (paired) list is handled by
+// mirrorOverrideToPair after the primary has been written.
+func (qt QuizType) PrimaryLogList() logList {
+	switch qt {
+	case QuizTypeReverse:
+		return listReverse
+	case QuizTypeEtymologyStandard, QuizTypeEtymologyFreeform:
+		return listEtymologyBreakdown
+	case QuizTypeEtymologyReverse:
+		return listEtymologyAssembly
+	default:
+		return listLearned
+	}
+}
+
+func getLogsByList(expr *LearningHistoryExpression, list logList) []LearningRecord {
+	switch list {
+	case listReverse:
+		return expr.ReverseLogs
+	case listEtymologyBreakdown:
+		return expr.EtymologyBreakdownLogs
+	case listEtymologyAssembly:
+		return expr.EtymologyAssemblyLogs
+	default:
+		return expr.LearnedLogs
+	}
+}
+
+func setLogsByList(expr *LearningHistoryExpression, list logList, logs []LearningRecord) {
+	switch list {
+	case listReverse:
+		expr.ReverseLogs = logs
+	case listEtymologyBreakdown:
+		expr.EtymologyBreakdownLogs = logs
+	case listEtymologyAssembly:
+		expr.EtymologyAssemblyLogs = logs
+	default:
+		expr.LearnedLogs = logs
+	}
 }
 
 // SetSkippedAt records a skip for the given quiz type at the given timestamp.

--- a/backend/internal/quiz/override_persistence_test.go
+++ b/backend/internal/quiz/override_persistence_test.go
@@ -1,0 +1,322 @@
+package quiz
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"gopkg.in/yaml.v3"
+
+	"github.com/at-ishikawa/langner/internal/config"
+	"github.com/at-ishikawa/langner/internal/dictionary/rapidapi"
+	"github.com/at-ishikawa/langner/internal/learning"
+	mock_inference "github.com/at-ishikawa/langner/internal/mocks/inference"
+	"github.com/at-ishikawa/langner/internal/notebook"
+)
+
+// TestService_OverrideAnswer_PersistsCorrectionToYAML reproduces the
+// reported bug: after a "misunderstood" answer on a standard vocabulary
+// quiz, clicking "Mark as Correct" must rewrite the YAML log so the
+// status flips to "understood" and quality goes from 1 to 4. The
+// service was silently no-op'ing for cases the on-disk reload didn't
+// surface, leaving the failure recorded.
+//
+// Real disk round-trip: seed YAML, call OverrideAnswer, re-read YAML,
+// assert the persisted shape — same pattern as the SkipWord tests.
+func TestService_OverrideAnswer_PersistsCorrectionToYAML_StandardScene(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	learningDir := t.TempDir()
+
+	// Seed: one notebook-type log marked misunderstood inside a scene.
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "test-story.yml"), []byte(`- metadata:
+    notebook_id: test-story
+    title: "Chapter One"
+  scenes:
+    - metadata:
+        title: "Opening"
+      expressions:
+        - expression: "preposterous"
+          learned_logs:
+            - status: misunderstood
+              learned_at: "2026-06-29T10:00:00Z"
+              quality: 1
+              quiz_type: notebook
+              interval_days: 1
+`), 0644))
+
+	svc := NewService(config.NotebooksConfig{
+		StoriesDirectories:     []string{t.TempDir()},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	markCorrect := true
+	info := CardInfo{
+		NotebookName: "test-story",
+		StoryTitle:   "Chapter One",
+		SceneTitle:   "Opening",
+		Expression:   "preposterous",
+		LearnedAt:    "2026-06-29",
+		MarkCorrect:  &markCorrect,
+	}
+
+	_, err := svc.OverrideAnswer(info, notebook.QuizTypeNotebook)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(learningDir, "test-story.yml"))
+	require.NoError(t, err)
+	var got []notebook.LearningHistory
+	require.NoError(t, yaml.Unmarshal(raw, &got))
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Scenes, 1)
+	require.Len(t, got[0].Scenes[0].Expressions, 1)
+	logs := got[0].Scenes[0].Expressions[0].LearnedLogs
+	require.Len(t, logs, 1, "override must not duplicate the log entry")
+	assert.Equal(t, notebook.LearnedStatus("understood"), logs[0].Status,
+		"Mark-as-Correct must flip misunderstood -> understood on disk")
+	assert.Equal(t, 4, logs[0].Quality, "override must bump quality from 1 to 4")
+}
+
+// Definitions-style note where Note.Definition is set, so the card's
+// Entry is the definition string but the YAML stores the original
+// Expression as the lookup key. The bug: toggleLastAnswer matches
+// against info.Expression == card.Entry (the definition), never
+// realising the YAML entry's expression is the original word, and
+// silently no-ops. The persisted log stays misunderstood even though
+// the user clicked Mark-as-Correct.
+func TestService_OverrideAnswer_PersistsCorrectionToYAML_DefinitionEntryFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	learningDir := t.TempDir()
+
+	// YAML stores under expression "serenity", but the quiz card's Entry
+	// would be the longer definition (Note.Definition != Note.Expression).
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "wpme.yml"), []byte(`- metadata:
+    notebook_id: wpme
+    title: "Session 3"
+  scenes:
+    - metadata:
+        title: "serenitas (calm)"
+      expressions:
+        - expression: "serenity"
+          learned_logs:
+            - status: misunderstood
+              learned_at: "2026-06-29T10:00:00Z"
+              quality: 1
+              quiz_type: notebook
+              interval_days: 1
+`), 0644))
+
+	svc := NewService(config.NotebooksConfig{
+		DefinitionsDirectories: []string{t.TempDir()},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	// Mimics CardInfoFromCard for a card built from a definition-bearing
+	// note: Expression carries the displayed definition (card.Entry).
+	// The matching YAML key is the original word (card.OriginalEntry),
+	// which the service must check as a fallback.
+	markCorrect := true
+	info := CardInfo{
+		NotebookName:       "wpme",
+		StoryTitle:         "Session 3",
+		SceneTitle:         "serenitas (calm)",
+		Expression:         "state of being calm and untroubled",
+		OriginalExpression: "serenity",
+		LearnedAt:          "2026-06-29",
+		MarkCorrect:        &markCorrect,
+	}
+
+	_, err := svc.OverrideAnswer(info, notebook.QuizTypeNotebook)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(learningDir, "wpme.yml"))
+	require.NoError(t, err)
+	var got []notebook.LearningHistory
+	require.NoError(t, yaml.Unmarshal(raw, &got))
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Scenes, 1)
+	require.Len(t, got[0].Scenes[0].Expressions, 1)
+	logs := got[0].Scenes[0].Expressions[0].LearnedLogs
+	require.Len(t, logs, 1)
+	assert.Equal(t, notebook.LearnedStatus("understood"), logs[0].Status,
+		"override must find the YAML entry by its original Expression key when the card's Entry is the Definition form")
+}
+
+// The frontend sends LearnedAt of the specific log the user clicked
+// Mark-as-Correct on. The backend must flip THAT log — not blindly
+// touch logs[0]. Test: mark a historical (older) misunderstood log
+// correct while a more recent understood log exists. The newer log
+// must not be touched.
+func TestService_OverrideAnswer_TargetsLearnedAt_NotJustLatest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	learningDir := t.TempDir()
+
+	// Newest log first (the YAML convention). The historical log at
+	// 2026-06-27 is the one the user is "marking correct" via Analytics.
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "test-story.yml"), []byte(`- metadata:
+    notebook_id: test-story
+    title: "Chapter One"
+  scenes:
+    - metadata:
+        title: "Opening"
+      expressions:
+        - expression: "preposterous"
+          learned_logs:
+            - status: understood
+              learned_at: "2026-06-29T10:00:00Z"
+              quality: 4
+              quiz_type: notebook
+              interval_days: 3
+            - status: misunderstood
+              learned_at: "2026-06-27T10:00:00Z"
+              quality: 1
+              quiz_type: notebook
+              interval_days: 1
+`), 0644))
+
+	svc := NewService(config.NotebooksConfig{
+		StoriesDirectories:     []string{t.TempDir()},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	info := CardInfo{
+		NotebookName: "test-story",
+		StoryTitle:   "Chapter One",
+		SceneTitle:   "Opening",
+		Expression:   "preposterous",
+		LearnedAt:    "2026-06-27", // The historical log the user clicked
+	}
+	markCorrect := true
+	info.MarkCorrect = &markCorrect
+
+	_, err := svc.OverrideAnswer(info, notebook.QuizTypeNotebook)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(learningDir, "test-story.yml"))
+	require.NoError(t, err)
+	var got []notebook.LearningHistory
+	require.NoError(t, yaml.Unmarshal(raw, &got))
+	logs := got[0].Scenes[0].Expressions[0].LearnedLogs
+	require.Len(t, logs, 2)
+	assert.Equal(t, notebook.LearnedStatus("understood"), logs[0].Status,
+		"newest log was already understood — override of historical log must leave it untouched")
+	assert.Equal(t, notebook.LearnedStatus("understood"), logs[1].Status,
+		"the historical log at LearnedAt=2026-06-27 should have flipped to understood")
+}
+
+// Freeform quizzes write each answer into both LearnedLogs AND
+// ReverseLogs (see YAMLLearningRepository.Create freeform branch). An
+// override that only touches one half leaves the two halves of the
+// same logical answer disagreeing. Both must flip together.
+func TestService_OverrideAnswer_Freeform_KeepsLearnedAndReverseLogsInSync(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	learningDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "test-story.yml"), []byte(`- metadata:
+    notebook_id: test-story
+    title: "Chapter One"
+  scenes:
+    - metadata:
+        title: "Opening"
+      expressions:
+        - expression: "preposterous"
+          learned_logs:
+            - status: misunderstood
+              learned_at: "2026-06-29T10:00:00Z"
+              quality: 1
+              quiz_type: freeform
+              interval_days: 1
+          reverse_logs:
+            - status: misunderstood
+              learned_at: "2026-06-29T10:00:00Z"
+              quality: 1
+              quiz_type: freeform
+              interval_days: 1
+`), 0644))
+
+	svc := NewService(config.NotebooksConfig{
+		StoriesDirectories:     []string{t.TempDir()},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	markCorrect := true
+	info := CardInfo{
+		NotebookName: "test-story",
+		StoryTitle:   "Chapter One",
+		SceneTitle:   "Opening",
+		Expression:   "preposterous",
+		LearnedAt:    "2026-06-29",
+		MarkCorrect:  &markCorrect,
+	}
+
+	_, err := svc.OverrideAnswer(info, notebook.QuizTypeFreeform)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(learningDir, "test-story.yml"))
+	require.NoError(t, err)
+	var got []notebook.LearningHistory
+	require.NoError(t, yaml.Unmarshal(raw, &got))
+	expr := got[0].Scenes[0].Expressions[0]
+	require.Len(t, expr.LearnedLogs, 1)
+	require.Len(t, expr.ReverseLogs, 1)
+	assert.Equal(t, expr.LearnedLogs[0].Status, expr.ReverseLogs[0].Status,
+		"freeform override must keep learned_logs and reverse_logs in sync")
+	assert.NotEqual(t, notebook.LearnedStatus("misunderstood"), expr.LearnedLogs[0].Status,
+		"override should have flipped misunderstood to a correct status")
+}
+
+// Flashcard variant: top-level Expressions (no Scenes). This is the
+// shape the user's vocabulary-book notebooks use.
+func TestService_OverrideAnswer_PersistsCorrectionToYAML_StandardFlashcard(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	learningDir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, "test-vocab.yml"), []byte(`- metadata:
+    notebook_id: test-vocab
+    title: "Basic Words"
+    type: flashcard
+  expressions:
+    - expression: "serendipity"
+      learned_logs:
+        - status: misunderstood
+          learned_at: "2026-06-29T10:00:00Z"
+          quality: 1
+          quiz_type: notebook
+          interval_days: 1
+`), 0644))
+
+	svc := NewService(config.NotebooksConfig{
+		FlashcardsDirectories:  []string{t.TempDir()},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	markCorrect := true
+	info := CardInfo{
+		NotebookName: "test-vocab",
+		StoryTitle:   "Basic Words",
+		Expression:   "serendipity",
+		LearnedAt:    "2026-06-29",
+		MarkCorrect:  &markCorrect,
+	}
+
+	_, err := svc.OverrideAnswer(info, notebook.QuizTypeNotebook)
+	require.NoError(t, err)
+
+	raw, err := os.ReadFile(filepath.Join(learningDir, "test-vocab.yml"))
+	require.NoError(t, err)
+	var got []notebook.LearningHistory
+	require.NoError(t, yaml.Unmarshal(raw, &got))
+	require.Len(t, got, 1)
+	require.Len(t, got[0].Expressions, 1)
+	logs := got[0].Expressions[0].LearnedLogs
+	require.Len(t, logs, 1)
+	assert.Equal(t, notebook.LearnedStatus("understood"), logs[0].Status)
+	assert.Equal(t, 4, logs[0].Quality)
+}

--- a/backend/internal/quiz/word_actions.go
+++ b/backend/internal/quiz/word_actions.go
@@ -1,13 +1,14 @@
 package quiz
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"path/filepath"
-	"strings"
 	"time"
 
+	"github.com/at-ishikawa/langner/internal/learning"
 	"github.com/at-ishikawa/langner/internal/notebook"
 )
 
@@ -28,34 +29,70 @@ func loadSingleLearningHistory(dir, notebookName string) ([]notebook.LearningHis
 
 // CardInfo holds the minimal information needed to identify a word
 // in the learning history for skip/resume/override operations.
+//
+// OriginalExpression carries the original Note.Expression form when
+// the card's Expression is actually a Definition (e.g. a definitions-
+// style notebook with a longer explanatory key). The YAML stores
+// learning history under Note.Expression, so override has to fall
+// back to OriginalExpression when matching by Expression misses.
+//
+// LearnedAt and MarkCorrect carry the user's intent on
+// OverrideAnswer: the specific log timestamp they clicked on (so the
+// service flips THAT entry, not blindly the latest) and the desired
+// correct/incorrect state (so the service idempotently applies the
+// intent instead of toggling whatever's there).
 type CardInfo struct {
-	NotebookName string
-	StoryTitle   string
-	SceneTitle   string
-	Expression   string
+	NotebookName       string
+	StoryTitle         string
+	SceneTitle         string
+	Expression         string
+	OriginalExpression string
+	LearnedAt          string
+	MarkCorrect        *bool
+	// NoteID is the DB primary key for the note this card represents,
+	// set by the handler when override is routed to a DB-backed repo.
+	// Zero when the card came from a YAML-only deployment (DB-side
+	// updates are a no-op in that case).
+	NoteID int64
+	// Used only by UndoOverrideAnswer — the pre-override snapshot the
+	// frontend captured when it first called OverrideAnswer, so the
+	// restore can put the log back to where it was without re-deriving
+	// quality from a now-flipped status.
+	OriginalQuality      int
+	OriginalStatus       string
+	OriginalIntervalDays int
 }
 
-// CardInfoFromCard converts a Card to CardInfo.
+// CardInfoFromCard converts a Card to CardInfo. OriginalExpression
+// preserves the Note.Expression form when the card was loaded with a
+// separate Definition entry — see CardInfo for why this fallback is
+// required.
 func CardInfoFromCard(card Card) CardInfo {
 	return CardInfo{
-		NotebookName: card.NotebookName,
-		StoryTitle:   card.StoryTitle,
-		SceneTitle:   card.SceneTitle,
-		Expression:   card.Entry,
+		NotebookName:       card.NotebookName,
+		StoryTitle:         card.StoryTitle,
+		SceneTitle:         card.SceneTitle,
+		Expression:         card.Entry,
+		OriginalExpression: card.OriginalEntry,
 	}
 }
 
 // CardInfoFromFreeformCard converts a FreeformCard to CardInfo.
 func CardInfoFromFreeformCard(card FreeformCard) CardInfo {
 	return CardInfo{
-		NotebookName: card.NotebookName,
-		StoryTitle:   card.StoryTitle,
-		SceneTitle:   card.SceneTitle,
-		Expression:   card.Expression,
+		NotebookName:       card.NotebookName,
+		StoryTitle:         card.StoryTitle,
+		SceneTitle:         card.SceneTitle,
+		Expression:         card.Expression,
+		OriginalExpression: card.OriginalExpression,
 	}
 }
 
-// CardInfoFromReverseCard converts a ReverseCard to CardInfo.
+// CardInfoFromReverseCard converts a ReverseCard to CardInfo. The
+// reverse-quiz prompt is the meaning, the user types the word, and
+// ReverseCard.Expression already holds Note.Expression — there's no
+// separate Definition-as-key form to disambiguate, so no
+// OriginalExpression fallback is needed here.
 func CardInfoFromReverseCard(card ReverseCard) CardInfo {
 	return CardInfo{
 		NotebookName: card.NotebookName,
@@ -168,97 +205,113 @@ func (s *Service) ResumeWord(info CardInfo, quizTypes []notebook.QuizType) error
 	return nil
 }
 
-// OverrideAnswer toggles the correctness of the most recent answer for a word.
-// Returns the new next review date string (YYYY-MM-DD format, empty if none).
-func (s *Service) OverrideAnswer(info CardInfo, quizType notebook.QuizType) (string, error) {
-	learningHistories, err := notebook.NewLearningHistories(s.notebooksConfig.LearningNotesDirectory)
+// OverrideResult captures the pre-change values of the affected log
+// plus the recomputed next-review date. Surfaces the original* fields
+// the frontend needs to render an "Undo" button after a Mark-as-Correct.
+type OverrideResult struct {
+	NextReviewDate       string
+	OriginalQuality      int
+	OriginalStatus       string
+	OriginalIntervalDays int
+}
+
+// OverrideAnswer rewrites the log identified by (info, quizType,
+// info.LearnedAt) according to info.MarkCorrect, on every configured
+// storage backend.
+//
+// Storage routing: the service hands the override to
+// s.learningRepository, which is whatever was wired at startup —
+// YAML, DB, or MultiLearningRepository(YAML+DB). YAML reproduces the
+// updater's full SM-2 recompute; DB does an UPDATE on
+// learning_logs(note_id, quiz_type, learned_at). For multi-store
+// setups, MultiLearningRepository runs the YAML write first and
+// mirrors the exact values onto the DB so the two stores agree.
+//
+// info.LearnedAt MUST be the timestamp of the specific log the user
+// clicked; the override targets THAT entry, not blindly logs[0]. When
+// info.MarkCorrect is nil the call is a no-op for status/quality
+// (kept for symmetry with the proto's optional field).
+//
+// Freeform variants flip the matching entry in both paired log lists
+// in the same call so the two halves of one logical freeform answer
+// stay consistent on disk.
+//
+// Returns the new next-review date as YYYY-MM-DD (empty when no
+// matching log was found).
+func (s *Service) OverrideAnswer(info CardInfo, quizType notebook.QuizType) (OverrideResult, error) {
+	if s.learningRepository == nil {
+		return OverrideResult{}, fmt.Errorf("no learning repository configured")
+	}
+	res, err := s.learningRepository.UpdateLog(context.Background(), learning.UpdateLogInput{
+		NoteID:             info.NoteID,
+		NotebookName:       info.NotebookName,
+		StoryTitle:         info.StoryTitle,
+		SceneTitle:         info.SceneTitle,
+		Expression:         info.Expression,
+		OriginalExpression: info.OriginalExpression,
+		QuizType:           string(quizType),
+		LearnedAt:          parseLearnedAt(info.LearnedAt),
+		MarkCorrect:        info.MarkCorrect,
+	})
 	if err != nil {
-		return "", fmt.Errorf("failed to load learning histories: %w", err)
+		return OverrideResult{}, fmt.Errorf("override learning log: %w", err)
 	}
-
-	updater := notebook.NewLearningHistoryUpdater(learningHistories[info.NotebookName], s.calculator)
-	nextReview := s.toggleLastAnswer(updater, info, quizType)
-
-	notePath := filepath.Join(s.notebooksConfig.LearningNotesDirectory, info.NotebookName+".yml")
-	if err := notebook.WriteYamlFile(notePath, updater.GetHistory()); err != nil {
-		return "", fmt.Errorf("failed to save learning history for %q: %w", info.NotebookName, err)
-	}
-	return nextReview, nil
+	return OverrideResult{
+		NextReviewDate:       res.NewNextReviewDate,
+		OriginalQuality:      res.OriginalQuality,
+		OriginalStatus:       res.OriginalStatus,
+		OriginalIntervalDays: res.OriginalIntervalDays,
+	}, nil
 }
 
-// UndoOverrideAnswer reverts the most recent answer override (toggles back).
-// Returns the new next review date string (YYYY-MM-DD format, empty if none).
-func (s *Service) UndoOverrideAnswer(info CardInfo, quizType notebook.QuizType) (string, error) {
-	return s.OverrideAnswer(info, quizType)
+// UndoOverrideAnswer restores a previously overridden log to the
+// captured pre-override values (passed via info.OriginalQuality /
+// OriginalStatus / OriginalIntervalDays). Returns the new next-review
+// date and whether the restored entry is now considered correct.
+//
+// Implementation note: undo is just an override with MirrorValues
+// pre-set to the originals — neither markCorrect nor the calculator
+// is consulted, so the restored row is byte-identical to what it was
+// before the user clicked Mark-as-Correct.
+func (s *Service) UndoOverrideAnswer(info CardInfo, quizType notebook.QuizType) (correct bool, nextReview string, err error) {
+	if s.learningRepository == nil {
+		return false, "", fmt.Errorf("no learning repository configured")
+	}
+	res, err := s.learningRepository.UpdateLog(context.Background(), learning.UpdateLogInput{
+		NoteID:             info.NoteID,
+		NotebookName:       info.NotebookName,
+		StoryTitle:         info.StoryTitle,
+		SceneTitle:         info.SceneTitle,
+		Expression:         info.Expression,
+		OriginalExpression: info.OriginalExpression,
+		QuizType:           string(quizType),
+		LearnedAt:          parseLearnedAt(info.LearnedAt),
+		MirrorValues: &learning.UpdateLogMirror{
+			Status:       info.OriginalStatus,
+			Quality:      info.OriginalQuality,
+			IntervalDays: info.OriginalIntervalDays,
+		},
+	})
+	if err != nil {
+		return false, "", fmt.Errorf("undo override learning log: %w", err)
+	}
+	correct = res.NewQuality >= 3
+	return correct, res.NewNextReviewDate, nil
 }
 
-// toggleLastAnswer toggles the correctness status and quality of the most recent
-// learning log entry. Returns the new next review date.
-func (s *Service) toggleLastAnswer(updater *notebook.LearningHistoryUpdater, info CardInfo, quizType notebook.QuizType) string {
-	for _, h := range updater.GetHistory() {
-		if h.Metadata.Title != info.StoryTitle {
-			continue
-		}
-
-		if len(h.Expressions) > 0 {
-			for ei, expr := range h.Expressions {
-				if !strings.EqualFold(expr.Expression, info.Expression) {
-					continue
-				}
-				return toggleLogs(&h.Expressions[ei], quizType, s.calculator)
-			}
-			continue
-		}
-
-		for _, scene := range h.Scenes {
-			if scene.Metadata.Title != info.SceneTitle {
-				continue
-			}
-			for ei, expr := range scene.Expressions {
-				if !strings.EqualFold(expr.Expression, info.Expression) {
-					continue
-				}
-				return toggleLogs(&scene.Expressions[ei], quizType, s.calculator)
-			}
-		}
+// parseLearnedAt accepts the YYYY-MM-DD or RFC3339 string the
+// frontend sends and returns the time.Time the repos look up by. An
+// unparseable string returns zero — UpdateLog implementations treat
+// that as a no-op.
+func parseLearnedAt(s string) time.Time {
+	if s == "" {
+		return time.Time{}
 	}
-	return ""
-}
-
-func toggleLogs(expr *notebook.LearningHistoryExpression, quizType notebook.QuizType, calculator notebook.IntervalCalculator) string {
-	logs := expr.GetLogsForQuizType(quizType)
-
-	if len(logs) == 0 {
-		return ""
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t
 	}
-
-	log := &logs[0]
-	if log.Status == notebook.LearnedStatusMisunderstood {
-		if quizType == notebook.QuizTypeEtymologyFreeform || quizType == notebook.QuizTypeFreeform {
-			log.Status = notebook.LearnedStatusCanBeUsed
-		} else {
-			log.Status = notebook.LearnedStatusUnderstood
-		}
-		log.Quality = 4
-	} else {
-		log.Status = notebook.LearnedStatusMisunderstood
-		log.Quality = 1
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return t
 	}
-
-	// Replay the older-log chain with this flipped entry appended so the
-	// recomputed interval matches what `validate --fix` would produce.
-	var previousLogs []notebook.LearningRecord
-	if len(logs) > 1 {
-		previousLogs = logs[1:]
-	}
-	newInterval, _ := calculator.NextIntervalForWrite(previousLogs, *log)
-	log.IntervalDays = newInterval
-
-	expr.SetLogsForQuizType(quizType, logs)
-
-	if newInterval > 0 {
-		nextDate := log.LearnedAt.AddDate(0, 0, newInterval)
-		return nextDate.Format("2006-01-02")
-	}
-	return ""
+	return time.Time{}
 }

--- a/backend/internal/server/quiz_handler.go
+++ b/backend/internal/server/quiz_handler.go
@@ -574,21 +574,52 @@ func (h *QuizHandler) SubmitEtymologyFreeformAnswer(ctx context.Context, req *co
 }
 
 func (h *QuizHandler) OverrideAnswer(ctx context.Context, req *connect.Request[apiv1.OverrideAnswerRequest]) (*connect.Response[apiv1.OverrideAnswerResponse], error) {
-	if err := validateRequest(req.Msg); err != nil { return nil, err }
+	if err := validateRequest(req.Msg); err != nil {
+		return nil, err
+	}
 	info, err := h.resolveCardInfo(ctx, req.Msg.GetNoteId())
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+	info.NoteID = req.Msg.GetNoteId()
+	info.LearnedAt = req.Msg.GetLearnedAt()
+	if req.Msg.MarkCorrect != nil {
+		mc := req.Msg.GetMarkCorrect()
+		info.MarkCorrect = &mc
+	}
 	quizType := protoQuizTypeToNotebook(req.Msg.GetQuizType())
-	nextReviewDate, err := h.svc.OverrideAnswer(*info, quizType)
-	if err != nil { return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("override answer: %w", err)) }
-	return connect.NewResponse(&apiv1.OverrideAnswerResponse{NextReviewDate: nextReviewDate}), nil
+	res, err := h.svc.OverrideAnswer(*info, quizType)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("override answer: %w", err))
+	}
+	return connect.NewResponse(&apiv1.OverrideAnswerResponse{
+		NextReviewDate:       res.NextReviewDate,
+		OriginalQuality:      int32(res.OriginalQuality),
+		OriginalStatus:       res.OriginalStatus,
+		OriginalIntervalDays: int32(res.OriginalIntervalDays),
+	}), nil
 }
 
 func (h *QuizHandler) UndoOverrideAnswer(ctx context.Context, req *connect.Request[apiv1.UndoOverrideAnswerRequest]) (*connect.Response[apiv1.UndoOverrideAnswerResponse], error) {
-	if err := validateRequest(req.Msg); err != nil { return nil, err }
+	if err := validateRequest(req.Msg); err != nil {
+		return nil, err
+	}
 	info, err := h.resolveCardInfo(ctx, req.Msg.GetNoteId())
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+	info.NoteID = req.Msg.GetNoteId()
+	info.LearnedAt = req.Msg.GetLearnedAt()
+	info.OriginalQuality = int(req.Msg.GetOriginalQuality())
+	info.OriginalStatus = req.Msg.GetOriginalStatus()
+	info.OriginalIntervalDays = int(req.Msg.GetOriginalIntervalDays())
 	quizType := protoQuizTypeToNotebook(req.Msg.GetQuizType())
-	nextReviewDate, err := h.svc.UndoOverrideAnswer(*info, quizType)
-	if err != nil { return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("undo override answer: %w", err)) }
-	return connect.NewResponse(&apiv1.UndoOverrideAnswerResponse{NextReviewDate: nextReviewDate}), nil
+	correct, nextReviewDate, err := h.svc.UndoOverrideAnswer(*info, quizType)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("undo override answer: %w", err))
+	}
+	return connect.NewResponse(&apiv1.UndoOverrideAnswerResponse{
+		Correct:        correct,
+		NextReviewDate: nextReviewDate,
+	}), nil
 }


### PR DESCRIPTION
Consolidated into #27 — the Mark-as-Correct fix commit was fast-forwarded onto `worktree-indexed-inventing-cookie`. Closing this PR; review the combined change in #27.