### PR TITLE
fix(quiz): tolerate spelling errors in meaning answers

### DIFF
--- a/backend/internal/inference/openai/client.go
+++ b/backend/internal/inference/openai/client.go
@@ -326,6 +326,12 @@ MARK CORRECT FOR THESE EQUIVALENCES:
    - If user provides alternatives (with "or", ";", "in this context")
    - If ANY alternative matches, mark CORRECT
 
+8. MINOR SPELLING ERRORS IN THE ANSWER:
+   - Judge the MEANING the user intended, not their spelling
+   - Typos, transposed/missing/extra letters, and small misspellings do NOT make an answer INCORRECT when the intended meaning is clear
+   - This holds even when a misspelling happens to look like another real word: infer intent from the whole answer, not the isolated token
+   - Spelling is NEVER a valid reason to mark INCORRECT
+
 === DECISION PROCESS ===
 
 1. First: Check for self-definition (STOP if found - mark INCORRECT)
@@ -334,8 +340,9 @@ MARK CORRECT FOR THESE EQUIVALENCES:
 4. Fourth: Check if context uses a compound term
 5. Fifth: Check IS vs USES error (category confusion)
 6. Sixth: Check PASSIVE vs ACTIVE error (direction reversal)
-7. Seventh: Apply semantic equivalence GENEROUSLY
-8. When uncertain: default to INCORRECT
+7. Seventh: Judge intended meaning, not spelling - ignore typos and misspellings
+8. Eighth: Apply semantic equivalence GENEROUSLY
+9. When uncertain: default to INCORRECT
 
 is_expression_input HANDLING
 - If true: expression may have typos; judge user's intended meaning
@@ -368,7 +375,7 @@ OUTPUT FORMAT:
 REASON FORMAT:
 - CORRECT: explain match (e.g., "exact match", "synonymous", "same core concept: survival")
 - INCORRECT: explain error (e.g., "self-definition", "IS vs USES: user described container not substance", "PASSIVE vs ACTIVE: user said victim but means resilience")
-- NEVER USE AS REASON: "context uses negation", "context implies X is not true"`
+- NEVER USE AS REASON: "context uses negation", "context implies X is not true", "spelling error", "misspelling", "typo"`
 
 	// promptExample to demonstrate correct evaluation patterns
 	type promptExample struct {
@@ -682,6 +689,28 @@ REASON FORMAT:
 					Meaning:    "the skill or work of making things from wood",
 					AnswersForContext: []inference.AnswersForContext{
 						{Correct: true, Context: "I don't know the first thing about carpentry.", Reason: "user correctly defines what carpentry IS - the context is about speaker's knowledge, not changing the word's meaning", Quality: 4},
+					},
+				},
+			},
+		},
+		{
+			description: "CORRECT - Minor spelling error: intended meaning is clear despite a typo that resembles another word",
+			userRequest: []inference.Expression{
+				{
+					Expression: "generous",
+					Meaning:    "willing to give and shair freely",
+					Contexts: []inference.Context{
+						{Context: "She was generous with her time and money.", ReferenceDefinition: "willing to give and share freely", Usage: "generous"},
+					},
+					IsExpressionInput: false,
+				},
+			},
+			assistantAnswer: []inference.AnswerMeaning{
+				{
+					Expression: "generous",
+					Meaning:    "willing to give and share freely",
+					AnswersForContext: []inference.AnswersForContext{
+						{Correct: true, Context: "She was generous with her time and money.", Reason: "matches the reference definition - 'shair' is a typo of 'share' and the intended meaning is clearly correct", Quality: 4},
 					},
 				},
 			},

--- a/backend/internal/inference/openai/client_integration_test.go
+++ b/backend/internal/inference/openai/client_integration_test.go
@@ -77,6 +77,18 @@ func TestClient_AnswerMeanings_Evaluate(t *testing.T) {
 					{Correct: false, Reason: "user meaning is about moving, not operating"},
 				},
 			},
+			{
+				Expression: inference.Expression{
+					Expression: "brave",
+					Meaning:    "showing corage when facing danger",
+					Contexts: []inference.Context{
+						{Context: "The brave firefighter ran into the burning building.", ReferenceDefinition: "showing courage when facing danger"},
+					},
+				},
+				Wants: []IntegrationTestTargetWant{
+					{Correct: true, Reason: "'corage' is a typo of 'courage'; intended meaning is correct and spelling must be ignored"},
+				},
+			},
 		}
 	}
 


### PR DESCRIPTION
## Problem

The vocabulary quiz's forward meaning grader marks a correctly-intended definition as **incorrect** when it contains a minor spelling error. This is most visible on quizzes sourced only from **definition and etymology notebooks** (no story context to disambiguate).

Reported example: a user typed a definition meaning *"lacking (a) conscience"* but misspelled the key word so it resembled a different, valid English word. The grader treated the misspelled token as a genuinely different concept and marked the answer wrong — *"incorrect definition due to spelling error"* ✗.

## Root cause

The reverse word-form validator (`ValidateWordForm`) already tolerates *"minor typos... small spelling errors that clearly show the user knows the word."* The **forward** meaning grader (`AnswerMeanings`) had **no** such guidance, so any misspelling in the typed meaning could trigger a WRONG verdict — especially when the misspelling looked like another real word.

## Fix

`backend/internal/inference/openai/client.go` — meaning-grader prompt only:

- Added a **"MINOR SPELLING ERRORS IN THE ANSWER"** rule to the *BE GENEROUS* section: judge the intended meaning, not spelling, even when a misspelling resembles another real word.
- Added a spelling step to the decision process.
- Added `"spelling error" / "misspelling" / "typo"` to the **NEVER USE AS REASON** list.
- Added a few-shot example: a misspelled-but-correct answer → CORRECT.
- Added a default integration test case (`client_integration_test.go`) covering a misspelled-but-correct meaning.

Per the repo's prompt rules, only general/common words are used in the prompt and no words are shared between the prompt's example and the test cases.

## Verification

- `go build ./...` ✓
- `go test ./internal/inference/openai/` ✓ (unit tests; mock-server based)
- `go vet` / `gofmt` clean ✓
- Live integration test (`-tags integration`) requires `OPENAI_API_KEY`, which is not available in this environment; the new default target exercises the spelling case when a key is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)