### PR TITLE
fix(relearn): stable note_id so re-starting a session can't misgrade cards

### DIFF
--- a/backend/internal/server/quiz_handler_relearn.go
+++ b/backend/internal/server/quiz_handler_relearn.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
+	"io"
 	"time"
 
 	"connectrpc.com/connect"
@@ -11,6 +13,26 @@ import (
 	"github.com/at-ishikawa/langner/internal/notebook"
 	"github.com/at-ishikawa/langner/internal/quiz"
 )
+
+// relearnCardID derives a stable note_id from a relearn card's identity so the
+// same card always gets the same id across StartRelearn calls. Grading looks
+// the card up by this id, so stability is what keeps a client's held id
+// pointing at the card it was shown — even after another StartRelearn. Keyed
+// by (format, notebook, entry, meaning): format separates a word failed in
+// several quiz types, and meaning separates two same-spelling senses
+// (homographs) that share an entry. The sign bit is masked off so the id is a
+// non-negative int64.
+func relearnCardID(card quiz.RelearnCard) int64 {
+	h := fnv.New64a()
+	_, _ = io.WriteString(h, string(card.Format))
+	_, _ = io.WriteString(h, "\x1f")
+	_, _ = io.WriteString(h, card.NotebookName)
+	_, _ = io.WriteString(h, "\x1f")
+	_, _ = io.WriteString(h, card.Entry)
+	_, _ = io.WriteString(h, "\x1f")
+	_, _ = io.WriteString(h, card.Meaning)
+	return int64(h.Sum64() >> 1)
+}
 
 // relearnDefaultWindowHours is used when the request leaves window_hours unset
 // (0). relearnMaxWindowHours caps the look-back at 7 days.
@@ -45,13 +67,11 @@ func (h *QuizHandler) StartRelearnQuiz(ctx context.Context, req *connect.Request
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("load relearn pool: %w", err))
 	}
 
-	localStore := make(map[int64]quiz.RelearnCard, len(cards))
-	var nextID int64 = 1
+	fresh := make(map[int64]quiz.RelearnCard, len(cards))
 	protoCards := make([]*apiv1.RelearnCard, 0, len(cards))
 	for _, card := range cards {
-		noteID := nextID
-		nextID++
-		localStore[noteID] = card
+		noteID := relearnCardID(card)
+		fresh[noteID] = card
 		var examples []*apiv1.Example
 		for _, ex := range card.Examples {
 			examples = append(examples, &apiv1.Example{Text: ex.Text, Speaker: ex.Speaker})
@@ -72,9 +92,23 @@ func (h *QuizHandler) StartRelearnQuiz(ctx context.Context, req *connect.Request
 		})
 	}
 
+	// Merge into the shared store rather than replacing it. note_id is now a
+	// stable hash of the card's content (relearnCardID), so a client that is
+	// still holding cards from an earlier StartRelearn — another browser tab,
+	// or re-entering the session within the window — submits an id that still
+	// resolves to the same card. The previous code replaced the store and
+	// handed out sequential ids assigned in random map-iteration order, so a
+	// re-start silently repointed a note_id at a different card: the learner
+	// saw one word's prompt but was graded against, and shown the meaning of,
+	// another. Merging keeps every issued id valid; the pool is small
+	// (recent wrong words) so unbounded growth is not a concern.
 	h.mu.Lock()
-	h.relearnStore = localStore
-	h.nextID = nextID
+	if h.relearnStore == nil {
+		h.relearnStore = make(map[int64]quiz.RelearnCard, len(fresh))
+	}
+	for id, card := range fresh {
+		h.relearnStore[id] = card
+	}
 	h.mu.Unlock()
 
 	return connect.NewResponse(&apiv1.StartRelearnQuizResponse{Cards: protoCards}), nil

--- a/backend/internal/server/quiz_handler_relearn_test.go
+++ b/backend/internal/server/quiz_handler_relearn_test.go
@@ -173,6 +173,50 @@ func TestRelearn_ReverseCardIsGradedByTheWordNotTheMeaning(t *testing.T) {
 	assert.False(t, submitDelta("a change or difference"), "typing the MEANING is wrong in a reverse card")
 }
 
+// TestRelearn_NoteIDsStableAcrossRestarts guards the card-store desync fix:
+// note_id is a stable hash of the card, so two StartRelearn calls hand the
+// same card the same id. The previous code assigned sequential ids in random
+// map-iteration order, so a re-start silently repointed a note_id at a
+// different card.
+func TestRelearn_NoteIDsStableAcrossRestarts(t *testing.T) {
+	h, _ := newRelearnTestHandler(t)
+
+	first := relearnByEntryType(startRelearn(t, h, 24))
+	second := relearnByEntryType(startRelearn(t, h, 24))
+
+	require.NotEmpty(t, first)
+	require.Len(t, second, len(first))
+	for key, c1 := range first {
+		c2, ok := second[key]
+		require.True(t, ok, "card %q must appear in both starts", key)
+		assert.Equal(t, c1.GetNoteId(), c2.GetNoteId(),
+			"note_id for %q must be identical across StartRelearn calls", key)
+	}
+}
+
+// TestRelearn_HeldNoteIDGradesTheCardItWasShownFor reproduces the reported bug:
+// a learner starts Relearn, then a second StartRelearn happens within the
+// window (another tab, or re-entering the session). Grading a note_id the
+// client is still holding must resolve to the SAME card it was shown — the
+// meaning returned matches the prompt and a correct answer is graded correct —
+// instead of whatever card a reassigned sequential id happened to land on.
+func TestRelearn_HeldNoteIDGradesTheCardItWasShownFor(t *testing.T) {
+	h, _ := newRelearnTestHandler(t)
+
+	held := relearnByEntryType(startRelearn(t, h, 24))["alpha/QUIZ_TYPE_STANDARD"]
+	require.NotNil(t, held)
+
+	// A second start replaces/extends the server store (the desync trigger).
+	_ = startRelearn(t, h, 24)
+
+	resp, err := h.SubmitRelearnAnswer(context.Background(),
+		connect.NewRequest(&apiv1.SubmitRelearnAnswerRequest{NoteId: held.GetNoteId(), Answer: "the first thing"}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetCorrect(), "the held note_id still grades the card it was shown for")
+	assert.Equal(t, held.GetMeaning(), resp.Msg.GetMeaning(),
+		"the graded card's meaning matches the one the learner saw — no cross-card desync")
+}
+
 func TestRelearn_PoolSelectsRecentWrongWordsAcrossTypes(t *testing.T) {
 	h, _ := newRelearnTestHandler(t)
 


### PR DESCRIPTION
## Symptom

In the Relearn quiz, the **question and answer didn't match** — the prompt showed one word but the revealed meaning belonged to a different word, and typing the correct answer for a reverse / etymology-reverse card was marked **incorrect**.

## Root cause

`StartRelearnQuiz` stored the resolved cards in a **single shared map on the handler** (`h.relearnStore`), keyed by a sequential `note_id` that reset to `1` on every call, and **replaced** the map each time. The pool itself is built by iterating a Go `map` (`candidates`), so the order — and thus which card gets `note_id = k` — is **random per call**.

Grading looks the card up server-side by `note_id` (`relearnStore[noteId]`), while the client renders from its own copy of the card and, in the feedback, shows `feedback.meaning` (the *server's* graded card). So if a second `StartRelearn` happened within the window — another browser tab, or re-entering the session — the store was replaced and every `note_id` was reassigned to a **different card**. A client still holding the earlier cards then submitted a `note_id` that resolved to an unrelated word:

- prompt shown = card A (client), graded against + meaning shown = card B (server) → **question/answer mismatch**;
- a correct answer for A graded against B → **marked incorrect**;
- the revealed meaning was B's → **"meaning of a different word."**

This is independent of the notebook/data and predates the homograph work — it's inherent to the relearn session store (feature #29).

## Fix

- Derive `note_id` from the card's **content** — `hash(format, notebook, entry, meaning)` — so the same card always gets the same id across `StartRelearn` calls (`meaning` also separates two same-spelling homograph senses).
- **Merge** the fresh cards into the store instead of replacing it, so every id ever handed out keeps resolving to its own card. Relearn still persists nothing; the pool is small (recent wrong words), so growth is a non-issue.

## Tests

- `TestRelearn_NoteIDsStableAcrossRestarts` — two `StartRelearn` calls hand the same card the same `note_id` (deterministic; fails under the old sequential-random scheme).
- `TestRelearn_HeldNoteIDGradesTheCardItWasShownFor` — after a second start, grading a `note_id` the client is still holding resolves to the same card: correct answer graded correct, and the returned meaning matches the one shown.

Verified: `go build`, `go vet`, `go test ./internal/server/…` green; golangci-lint v2.5.0 → 0 issues.

## Note

The other quiz stores (standard / reverse / etymology) share the same `h.nextID` + replace-store pattern, but they run as single foreground sessions and persist their results, so they don't exhibit this cross-card desync. Scoped this fix to Relearn as reported; the shared-`nextID` pattern could be revisited separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)