### PR TITLE
fix(quiz): definitions/etymology words show their example sentence in the standard (and reverse) quiz

### DIFF
--- a/backend/internal/quiz/service.go
+++ b/backend/internal/quiz/service.go
@@ -1969,6 +1969,13 @@ func loadDefinitionCards(reader *notebook.Reader, bookID string, learningHistori
 				} else {
 					originalEntry = note.Expression
 				}
+				// Mirror loadFlashcardCards: surface each entry's example
+				// sentences so definitions-book / etymology-derived words
+				// show their examples in the standard quiz.
+				var examples []Example
+				for _, ex := range note.Examples {
+					examples = append(examples, Example{Text: ex})
+				}
 				card := Card{
 					ID:            note.ID,
 					NotebookName:  bookID,
@@ -1977,6 +1984,7 @@ func loadDefinitionCards(reader *notebook.Reader, bookID string, learningHistori
 					Entry:         entry,
 					OriginalEntry: originalEntry,
 					Meaning:       note.Meaning,
+					Examples:      examples,
 					WordDetail:    buildWordDetail(&note, originMap),
 				}
 				// Decorate via byMember so non-head members of non-family
@@ -2042,12 +2050,27 @@ func loadDefinitionReverseCards(reader *notebook.Reader, bookID string, learning
 					expression = note.Definition
 					altForm = note.Expression
 				}
+				// Mirror loadFlashcardReverseCards: build masked example
+				// contexts so a definitions-book word behaves like a
+				// flashcard word in reverse mode (same expression/definition
+				// masking).
+				var contexts []ReverseContext
+				for _, ex := range note.Examples {
+					if strings.Contains(strings.ToLower(ex), strings.ToLower(note.Expression)) {
+						masked := maskWord(ex, note.Expression, note.Definition)
+						contexts = append(contexts, ReverseContext{
+							Context:       ex,
+							MaskedContext: masked,
+						})
+					}
+				}
 				card := ReverseCard{
 					ID:           note.ID,
 					NotebookName: bookID,
 					StoryTitle:   storyTitle,
 					SceneTitle:   sceneTitle,
 					Meaning:      note.Meaning,
+					Contexts:     contexts,
 					Expression:   expression,
 					AltForm:      altForm,
 					WordDetail:   buildWordDetail(&note, originMap),

--- a/backend/internal/quiz/service_test.go
+++ b/backend/internal/quiz/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -747,6 +748,67 @@ notebooks:
 	require.NotNil(t, book)
 	assert.Equal(t, 2, book.ReverseReviewCount,
 		"summary ReverseReviewCount with includeUnstudied must match the 2 reverse cards loaded")
+}
+
+// TestService_LoadCards_DefinitionsBook_SurfacesExamples verifies that a
+// definitions-book (incl. etymology-derived) word's `examples:` sentences
+// reach the standard quiz Card (forward) and the reverse Card's masked
+// Contexts (reverse). Before the fix, loadDefinitionCards never read
+// note.Examples (Card.Examples stayed nil) and loadDefinitionReverseCards
+// built no Contexts, so definitions words showed no example sentence while
+// flashcard words did.
+func TestService_LoadCards_DefinitionsBook_SurfacesExamples(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defsDir := t.TempDir()
+	learningDir := t.TempDir()
+
+	const example = "His grasp of the language was barely passable at first, but it improved."
+
+	bookDir := filepath.Join(defsDir, "examples-defs")
+	require.NoError(t, os.MkdirAll(bookDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(bookDir, "index.yml"), []byte(`id: examples-defs
+notebooks:
+  - ./session1.yml
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(bookDir, "session1.yml"), []byte(`- metadata:
+    title: "Session 1"
+  scenes:
+    - metadata:
+        index: 0
+        title: "roots"
+      expressions:
+        - expression: "passable"
+          meaning: "good enough, but not excellent"
+          examples:
+            - "`+example+`"
+`), 0o644))
+
+	svc := NewService(config.NotebooksConfig{
+		DefinitionsDirectories: []string{defsDir},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil), config.QuizConfig{})
+
+	// Forward: the standard quiz Card must carry the example sentence.
+	cards, err := svc.LoadCards([]string{"examples-defs"}, true, nil)
+	require.NoError(t, err)
+	require.Len(t, cards, 1)
+	require.Len(t, cards[0].Examples, 1,
+		"definitions-book word must surface its example sentence (was nil before the fix)")
+	assert.Equal(t, example, cards[0].Examples[0].Text)
+
+	// Reverse: the reverse Card must carry a masked context built from the
+	// same example, with the expression masked out.
+	reverse, err := svc.LoadReverseCards([]string{"examples-defs"}, false, true, nil)
+	require.NoError(t, err)
+	require.Len(t, reverse, 1)
+	require.Len(t, reverse[0].Contexts, 1,
+		"definitions-book reverse card must build masked contexts (was empty before the fix)")
+	assert.Equal(t, example, reverse[0].Contexts[0].Context)
+	assert.NotContains(t, strings.ToLower(reverse[0].Contexts[0].MaskedContext), "passable",
+		"the expression must be masked out of the reverse context")
+	assert.Contains(t, reverse[0].Contexts[0].MaskedContext, "______",
+		"masking must replace the expression with the blank marker")
 }
 
 // TestService_LoadDefinitionWords_RespectsFreeformSkip exercises the


### PR DESCRIPTION
## Root cause

In the standard vocabulary quiz, cards loaded from a **definitions book** (including etymology-derived books like `latin-and-greek-roots-1`) did not show their example sentence, even though each entry has an `examples:` array.

`loadDefinitionCards` in `backend/internal/quiz/service.go` built each `Card` but **never read `note.Examples`**, so `Card.Examples` stayed `nil`. The working flashcard path `loadFlashcardCards` does `for _, ex := range card.Examples { … Example{Text: ex} }`.

The reverse-quiz analog had the same gap: `loadDefinitionReverseCards` set no `Contexts`, whereas `loadFlashcardReverseCards` builds masked example contexts.

## The fix (parity with the flashcard loaders)

1. **Forward (standard quiz):** `loadDefinitionCards` now populates `Card.Examples` from `note.Examples`, mirroring `loadFlashcardCards` exactly (`Example{Text: ex}`).
2. **Reverse quiz:** `loadDefinitionReverseCards` now builds masked example `Contexts` from `note.Examples` via `maskWord(ex, note.Expression, note.Definition)`, identical masking to `loadFlashcardReverseCards`.

No new formatting/structs — reuses the same `Example` / `ReverseContext` types and `maskWord` helper the flashcard paths use.

**No frontend change needed:** `frontend/src/app/quiz/standard/page.tsx` already renders `card.examples`; the data was simply missing.

**Not a learning-history change:** this only affects card content (example sentences / masked contexts). It does not alter how a card's storage key / expression is derived, so the learning-history invariants are unaffected.

## Tests

Added `TestService_LoadCards_DefinitionsBook_SurfacesExamples` in `internal/quiz/service_test.go`: a definitions-book note with an `examples:` entry produces a standard `Card` whose `Examples` contains that sentence (forward), and a reverse card whose masked `Contexts` are built from it (expression masked to `______`). The assertions target exactly the fields that were empty pre-fix.

## Overlap note

Two other PRs are in flight that also touch `backend/internal/quiz/service.go` — PR #41 `feat/etymology-vocab-quiz-relearn` and a `fix/vocab-tab-notebooks-with-vocabulary` branch. This PR edits **different functions** (`loadDefinitionCards` / `loadDefinitionReverseCards` card-building) and ships against `main` independently; expect only trivial, non-semantic merge overlap if any.

## Verification

- `go build ./...` — clean.
- `go test ./...` — all packages green (including the new test and the existing `internal/quiz` suite).
- `gofmt -l` on the touched files — no diff.
- Grepped the diff for personal notebook identifiers — none; used generic examples (`passable`).
- Confirmed the standard-quiz frontend already renders `card.examples` (no FE change).
- Not run in this sandbox: live browser flow and Postgres e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)