### PR TITLE
fix(relearn): show origin-family word's example scenes in feedback

### DIFF
--- a/frontend/src/components/RelearnOriginPost.test.tsx
+++ b/frontend/src/components/RelearnOriginPost.test.tsx
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { RelearnOriginPost } from "./RelearnOriginPost";
-import type { RelearnCard } from "@/lib/client";
+import type { RelearnCard, SubmitRelearnAnswerResponse } from "@/lib/client";
+import { quizClient } from "@/lib/client";
 
 vi.mock("@/lib/client", () => ({
   quizClient: { submitRelearnAnswer: vi.fn() },
   QuizType: { QUIZ_TYPE_UNSPECIFIED: 0, STANDARD: 1, REVERSE: 2, FREEFORM: 3, ETYMOLOGY_ORIGIN: 4, RELEARN: 7, GRAMMAR: 8 },
 }));
+
+const submitMock = vi.mocked(quizClient.submitRelearnAnswer);
 
 const word = (entry: string, noteId: number): RelearnCard =>
   ({
@@ -40,6 +43,20 @@ function renderPost(englishForms: string[]) {
   );
 }
 
+// A graded response for one word. contextScenes drives the "Where it appears"
+// section; correct=false makes the feedback sheet open automatically.
+const gradeResponse = (
+  overrides: Partial<SubmitRelearnAnswerResponse> = {},
+): SubmitRelearnAnswerResponse =>
+  ({
+    correct: false,
+    meaning: "free",
+    reason: "",
+    literal: "",
+    contextScenes: [],
+    ...overrides,
+  }) as SubmitRelearnAnswerResponse;
+
 describe("RelearnOriginPost", () => {
   it("renders the origin's english_forms as chips on the header", () => {
     renderPost(["lib", "liv"]);
@@ -52,5 +69,50 @@ describe("RelearnOriginPost", () => {
   it("omits the chip row when there are no english_forms", () => {
     renderPost([]);
     expect(screen.queryByTestId("relearn-origin-english-forms")).not.toBeInTheDocument();
+  });
+
+  it("shows the word's example scenes in the feedback sheet when it is graded with contextScenes", async () => {
+    submitMock.mockResolvedValueOnce(
+      gradeResponse({
+        contextScenes: [
+          {
+            notebookName: "nb",
+            sceneTitle: "At the library",
+            statements: ["They fought for liberty and freedom."],
+            conversations: [],
+          },
+        ] as SubmitRelearnAnswerResponse["contextScenes"],
+      }),
+    );
+    renderPost(["lib", "liv"]);
+
+    const input = screen.getByLabelText('Meaning for "liberty"');
+    fireEvent.change(input, { target: { value: "wrong guess" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const sheet = await screen.findByTestId("relearn-origin-feedback");
+    await waitFor(() => {
+      expect(sheet).toHaveTextContent("Where it appears");
+      expect(sheet).toHaveTextContent("They fought for liberty and freedom.");
+    });
+  });
+
+  it("renders no example scenes for a word graded without contextScenes", async () => {
+    // contextScenes absent → the `?? []` fallback → RelearnContext renders null.
+    submitMock.mockResolvedValueOnce({
+      correct: false,
+      meaning: "free",
+      reason: "",
+      literal: "",
+    } as SubmitRelearnAnswerResponse);
+    renderPost(["lib", "liv"]);
+
+    const input = screen.getByLabelText('Meaning for "liberty"');
+    fireEvent.change(input, { target: { value: "wrong guess" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    const sheet = await screen.findByTestId("relearn-origin-feedback");
+    await waitFor(() => expect(sheet).toHaveTextContent("wrong guess"));
+    expect(sheet).not.toHaveTextContent("Where it appears");
   });
 });

--- a/frontend/src/components/RelearnOriginPost.tsx
+++ b/frontend/src/components/RelearnOriginPost.tsx
@@ -8,6 +8,7 @@ import {
   type SubmitRelearnAnswerResponse,
 } from "@/lib/client";
 import { OriginBreakdown } from "@/components/OriginBreakdown";
+import RelearnContext from "@/components/RelearnContext";
 import { responseTimeSince } from "@/lib/responseTime";
 
 // RelearnOriginPost presents ONE etymology origin the way the etymology family
@@ -378,6 +379,14 @@ export function RelearnOriginPost({
               {selected.res.literal}
             </Text>
           )}
+          {/* Where-it-appears example scenes for the graded word, mirroring the
+              single-card Relearn screen. RelearnContext returns null on empty
+              scenes, so a word without examples renders nothing extra. */}
+          <RelearnContext
+            entry={selectedWord.entry}
+            scenes={selected.res.contextScenes ?? []}
+            exampleWords={[]}
+          />
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## What

In the **Relearn** etymology **origin-family card** (`frontend/src/components/RelearnOriginPost.tsx`), the per-word feedback sheet did not show the missed word's example statements / "Where it appears" context — even though the normal single-card vocab/reverse Relearn screen already shows them.

This adds that context to the origin-family card's pinned feedback sheet.

## Why

Confirmed frontend-only display omission — the data already arrives:
- The backend populates example scenes for etymology-origin relearn cards: `backend/internal/quiz/relearn.go` sets `ContextScenes: relearnScenesFromCard(fc)`, and `backend/internal/server/quiz_handler_relearn.go` returns `context_scenes` on the per-word `SubmitRelearnAnswer` response for all cards (no etymology gating). Proto field: `SubmitRelearnAnswerResponse.context_scenes`.
- The single-card path renders it via `<RelearnContext scenes={feedback.contextScenes ?? []} … />` (`frontend/src/app/quiz/relearn/session/page.tsx`).
- `RelearnOriginPost` had the value available on `selected.res.contextScenes` but never rendered it.

## How

- Import `RelearnContext` and render it inside the **existing** pinned `position="fixed"` feedback bottom sheet (which already has `maxH`/`overflowY="auto"`), after the literal block, keyed to the currently-selected graded word — mirroring the single-card path:
  ```tsx
  <RelearnContext entry={selectedWord.entry} scenes={selected.res.contextScenes ?? []} exampleWords={[]} />
  ```
- `RelearnContext` returns `null` on empty scenes, so words without examples render nothing extra.

Nine-line component change plus tests; no other surface touched.

## Learning-log / invariants impact

**Display-only.** No log-write / grade / skip / exclude path is touched (no `SkipWord`/`ResumeWord`, no `is_skipped`). Re-checked `quiz-ui-invariants` (esp. U3 — feedback stays inside the pinned sheet adjacent to its item and visible without scrolling past Next; it opens only for a graded word, matching current behavior) and `learning-history-invariants`. Relearn still persists nothing.

## How verified

- `vitest` (`RelearnOriginPost.test.tsx`): new tests assert the "Where it appears" statements render in the feedback sheet when a word is graded with populated `contextScenes`, and that a word graded without scenes renders no context. All 4 tests pass. Generic example data only (Latin root `liber` / "liberty" / "liberal").
- `eslint .` — 0 errors (pre-existing warnings only).
- Coverage delta is positive vs. `main` on this file (both `?? []` branches exercised).
- A live browser run is blocked by the known Turbopack `/work`-mount panic, so verification falls back to the component test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)