### PR TITLE
fix(quiz): load etymology-notebook embedded words as vocabulary + group in Relearn

### DIFF
--- a/backend/internal/notebook/etymology.go
+++ b/backend/internal/notebook/etymology.go
@@ -585,6 +585,43 @@ func (r *Reader) ReadAllEtymologyDefinitions() []EtymologyDefinitionEntry {
 	return allDefs
 }
 
+// ReadEtymologyNotebookDefinitions reads origin-bearing definitions embedded
+// ONLY in dedicated etymology-notebook session files (config
+// etymology_directories) — the subset of ReadAllEtymologyDefinitions that no
+// other card loader ever sees. Story- and flashcard-embedded etymology
+// definitions are already loaded by their own loaders; the words that live
+// INSIDE an etymology notebook are the gap: they were surfaced on the etymology
+// browse page but never became quiz cards. NotebookName is set to the index ID
+// (not the display Name) so the learning-log write/read path stays symmetric
+// with every other loader (learning-history-invariants L2).
+func (r *Reader) ReadEtymologyNotebookDefinitions() []EtymologyDefinitionEntry {
+	var defs []EtymologyDefinitionEntry
+	seen := make(map[string]bool) // guard against a notebook listed twice
+	for _, index := range r.etymologyIndexes {
+		for _, nbPath := range index.NotebookPaths {
+			path := filepath.Join(index.Path, nbPath)
+			if seen[path] {
+				continue
+			}
+			seen[path] = true
+			wrapped, err := readYamlFile[etymologySessionFile](path)
+			if err != nil {
+				continue
+			}
+			sessionTitle := strings.TrimSpace(wrapped.Metadata.Title)
+			for _, def := range wrapped.Definitions {
+				if len(def.OriginParts) == 0 {
+					continue
+				}
+				def.NotebookName = index.ID
+				def.SessionTitle = sessionTitle
+				defs = append(defs, def)
+			}
+		}
+	}
+	return defs
+}
+
 // GetEtymologyIndexes returns the etymology indexes map.
 func (r *Reader) GetEtymologyIndexes() map[string]EtymologyIndex {
 	return r.etymologyIndexes

--- a/backend/internal/quiz/relearn_test.go
+++ b/backend/internal/quiz/relearn_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -630,4 +631,157 @@ func TestLoadRelearnPool_EtymologyCardCarriesEnglishForms(t *testing.T) {
 	require.Contains(t, got, "describe")
 	assert.Equal(t, []string{"scrib", "script"}, got["describe"].EnglishForms,
 		"the origin's english_forms must be threaded onto the relearn family card")
+}
+
+// etymologyEmbeddedFixture wires an etymology notebook whose session file
+// EMBEDS its own origin-bearing definitions (a `definitions:` block inside the
+// etymology YAML) — the exact shape that, before this fix, was surfaced on the
+// etymology browse page but never loaded by any quiz-card loader. `dupWord`, if
+// non-empty, is ALSO placed in a separate definitions book so the dedup rule can
+// be exercised: the definitions-book entry must win and the etymology-notebook
+// copy must be skipped (learning-history-invariants L1/L4 — one series per word).
+func etymologyEmbeddedFixture(t *testing.T, dupWord string, missed ...string) *Service {
+	t.Helper()
+	dir := t.TempDir()
+	etymDir := filepath.Join(dir, "etymology")
+	defsDir := filepath.Join(dir, "definitions")
+	learningDir := filepath.Join(dir, "learning")
+	const etymID = "etym-roots"
+
+	etymBook := filepath.Join(etymDir, etymID)
+	require.NoError(t, os.MkdirAll(etymBook, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(etymBook, "index.yml"), []byte(
+		"id: "+etymID+"\nkind: Etymology\nname: Etym Roots\nnotebooks:\n  - ./s1.yml\n"), 0644))
+	// Legacy wrapped shape with an embedded definitions block. "dictate" and
+	// "predict" both derive from the origin "dict".
+	require.NoError(t, os.WriteFile(filepath.Join(etymBook, "s1.yml"), []byte(`metadata:
+  title: "Session 1"
+origins:
+  - origin: "dict"
+    type: root
+    language: Latin
+    meaning: to say, to speak
+    english_forms: [dict, dic]
+definitions:
+  - expression: dictate
+    meaning: to say aloud for another to record
+    note: 'dict "say" = "say aloud"'
+    origin_parts:
+      - origin: dict
+  - expression: predict
+    meaning: to say beforehand
+    origin_parts:
+      - origin: dict
+`), 0644))
+
+	// A separate definitions book. When dupWord is set it contains that word so
+	// the same expression exists in BOTH books; the definitions copy is canonical.
+	if dupWord != "" {
+		defsBook := filepath.Join(defsDir, "defs")
+		require.NoError(t, os.MkdirAll(defsBook, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(defsBook, "index.yml"), []byte(
+			"id: defs\nnotebooks:\n  - ./s1.yml\n"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(defsBook, "s1.yml"), []byte(`- metadata:
+    title: "Book 1"
+  scenes:
+  - metadata:
+      index: 0
+      title: S1
+    expressions:
+    - expression: `+dupWord+`
+      meaning: canonical meaning from the definitions book
+`), 0644))
+	}
+
+	require.NoError(t, os.MkdirAll(learningDir, 0755))
+	recent := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	exprs := ""
+	for _, w := range missed {
+		exprs += fmt.Sprintf(`    - expression: %s
+      type: vocabulary
+      learned_logs:
+        - status: misunderstood
+          learned_at: "%s"
+`, w, recent)
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(learningDir, etymID+".yml"), []byte(
+		"- metadata:\n    id: "+etymID+"\n    title: \"Session 1\"\n    type: definition\n  expressions:\n"+exprs), 0644))
+
+	ctrl := gomock.NewController(t)
+	return NewService(config.NotebooksConfig{
+		EtymologyDirectories:   []string{etymDir},
+		DefinitionsDirectories: []string{defsDir},
+		LearningNotesDirectory: learningDir,
+	}, mock_inference.NewMockClient(ctrl), make(map[string]rapidapi.Response),
+		learning.NewYAMLLearningRepository(learningDir, nil),
+		config.QuizConfig{Algorithm: "modified_sm2", FixedIntervals: []int{1, 7, 30, 90, 365, 1095, 1825}, DisableShuffle: true})
+}
+
+func freeformByExpr(cards []FreeformCard) map[string][]FreeformCard {
+	out := map[string][]FreeformCard{}
+	for _, c := range cards {
+		out[strings.ToLower(c.Expression)] = append(out[strings.ToLower(c.Expression)], c)
+	}
+	return out
+}
+
+// TestLoadAllWords_IncludesEtymologyNotebookWord pins the core fix: an
+// origin-bearing definition embedded INSIDE an etymology notebook becomes an
+// ordinary vocabulary card (quizzable) with its origin resolved.
+func TestLoadAllWords_IncludesEtymologyNotebookWord(t *testing.T) {
+	svc := etymologyEmbeddedFixture(t, "")
+
+	words, err := svc.LoadAllWords()
+	require.NoError(t, err)
+	byExpr := freeformByExpr(words)
+
+	require.Contains(t, byExpr, "dictate", "an etymology-notebook embedded word must now be quizzable")
+	require.Len(t, byExpr["dictate"], 1, "exactly one canonical card per word")
+	card := byExpr["dictate"][0]
+	assert.Equal(t, "etym-roots", card.NotebookName, "NotebookName must be the etymology book ID for symmetric read/write")
+	assert.Equal(t, "to say aloud for another to record", card.Meaning)
+	require.Len(t, card.WordDetail.OriginParts, 1, "origin_parts must resolve against the etymology origin map")
+	assert.Equal(t, "dict", card.WordDetail.OriginParts[0].Origin)
+	assert.Equal(t, "to say, to speak", card.WordDetail.OriginParts[0].Meaning)
+	_, hasOrigin := primaryOriginPart(card)
+	assert.True(t, hasOrigin, "the word must carry a primary origin so it groups in Relearn")
+}
+
+// TestLoadAllWords_DedupEtymologyVsDefinitions pins the canonical-dedup rule
+// (L1/L4): a word present in BOTH an etymology notebook and a definitions book
+// loads exactly once, and the definitions-book entry wins.
+func TestLoadAllWords_DedupEtymologyVsDefinitions(t *testing.T) {
+	svc := etymologyEmbeddedFixture(t, "predict")
+
+	words, err := svc.LoadAllWords()
+	require.NoError(t, err)
+	byExpr := freeformByExpr(words)
+
+	require.Len(t, byExpr["predict"], 1, "a word in both books must produce ONE card (one log series)")
+	assert.Equal(t, "defs", byExpr["predict"][0].NotebookName,
+		"the definitions-book entry is canonical; the etymology-notebook copy is skipped")
+	assert.Equal(t, "canonical meaning from the definitions book", byExpr["predict"][0].Meaning)
+	// The non-duplicated etymology-notebook word is still loaded.
+	require.Contains(t, byExpr, "dictate")
+	require.Len(t, byExpr["dictate"], 1)
+}
+
+// TestLoadRelearnPool_EtymologyNotebookWordGroups pins that a missed
+// etymology-notebook embedded word enters the Relearn pool as a
+// QUIZ_TYPE_ETYMOLOGY_ORIGIN card (with origin header) so the frontend groups it
+// by origin — the same treatment definitions-book origin words already get.
+func TestLoadRelearnPool_EtymologyNotebookWordGroups(t *testing.T) {
+	svc := etymologyEmbeddedFixture(t, "", "dictate", "predict")
+
+	pool, err := svc.LoadRelearnPool(time.Now().Add(-24 * time.Hour))
+	require.NoError(t, err)
+	got := etymRelearnByEntry(pool)
+
+	require.Contains(t, got, "dictate", "a missed etymology-notebook word must group as a family card")
+	require.Contains(t, got, "predict")
+	assert.True(t, got["dictate"].IsEtymology())
+	assert.Equal(t, "dict", got["dictate"].OriginText)
+	assert.Equal(t, "to say, to speak", got["dictate"].OriginMeaning)
+	assert.Equal(t, "to say aloud for another to record", got["dictate"].Meaning)
+	assert.Equal(t, []string{"dict", "dic"}, got["dictate"].EnglishForms)
 }

--- a/backend/internal/quiz/service.go
+++ b/backend/internal/quiz/service.go
@@ -1457,7 +1457,76 @@ func (s *Service) LoadAllWords() ([]FreeformCard, error) {
 		cards = append(cards, defWords...)
 	}
 
+	// Etymology-notebook embedded words: origin-bearing definitions that live
+	// INSIDE a dedicated etymology notebook (config etymology_directories).
+	// Before this they were surfaced on the etymology browse page but never
+	// loaded as quiz cards, so they were neither quizzable as ordinary
+	// vocabulary nor groupable by origin in Relearn. Load them as ordinary
+	// FreeformCards so they flow through the SAME paths as every other word
+	// (the freeform quiz here, and the relearn vocab index, which is built from
+	// LoadAllWords).
+	//
+	// Canonical-dedup rule (learning-history-invariants L1/L4 — exactly one log
+	// series per word): a story / flashcard / definitions entry ALWAYS wins. An
+	// etymology-notebook copy is added ONLY when no other loader already
+	// provides that expression, deduped case-insensitively on the canonical
+	// expression. So a word embedded in an etymology notebook AND present in a
+	// definitions/story/flashcard book keeps a single canonical card, and
+	// therefore a single learning-log series.
+	cards = appendEtymologyNotebookWords(reader, cards, originMap)
+
 	return cards, nil
+}
+
+// appendEtymologyNotebookWords adds each etymology-notebook embedded,
+// origin-bearing definition to cards, unless another loader already provided a
+// card for the same canonical expression (see the dedup rule in LoadAllWords).
+func appendEtymologyNotebookWords(reader *notebook.Reader, cards []FreeformCard, originMap map[string]notebook.EtymologyOrigin) []FreeformCard {
+	seen := make(map[string]bool, len(cards))
+	for _, c := range cards {
+		for _, e := range []string{c.Expression, c.OriginalExpression} {
+			if e = strings.ToLower(strings.TrimSpace(e)); e != "" {
+				seen[e] = true
+			}
+		}
+	}
+
+	for _, def := range reader.ReadEtymologyNotebookDefinitions() {
+		// Canonicalize with Definition precedence — the same rule the
+		// definitions-book loader uses — so a word present in both a
+		// definitions book and an etymology notebook deduplicates.
+		expression := def.Expression
+		if def.Definition != "" {
+			expression = def.Definition
+		}
+		key := strings.ToLower(strings.TrimSpace(expression))
+		if key == "" || seen[key] {
+			continue // another loader already owns this word's canonical series
+		}
+		seen[key] = true
+
+		// buildWordDetail resolves origin_parts against originMap so
+		// primaryOriginPart returns the origin and the miss enters the existing
+		// ETYMOLOGY_ORIGIN grouping branch in LoadRelearnPool.
+		note := notebook.Note{
+			Expression:   def.Expression,
+			Definition:   def.Definition,
+			Meaning:      def.Meaning,
+			PartOfSpeech: def.PartOfSpeech,
+			Note:         def.Note,
+			OriginParts:  def.OriginParts,
+		}
+		cards = append(cards, FreeformCard{
+			NotebookName:       def.NotebookName,
+			StoryTitle:         def.SessionTitle,
+			Expression:         expression,
+			OriginalExpression: def.Expression,
+			Meaning:            def.Meaning,
+			WordDetail:         buildWordDetail(&note, originMap),
+			Literal:            def.Note,
+		})
+	}
+	return cards
 }
 
 func (s *Service) loadStoryWords(reader *notebook.Reader, notebookID string, originMap map[string]notebook.EtymologyOrigin) ([]FreeformCard, error) {


### PR DESCRIPTION
## Problem

Origin-bearing definitions embedded **inside a dedicated etymology notebook** (config `etymology_directories`) were surfaced on the etymology browse page but **never loaded by any quiz-card loader**. Consequences:

1. They were **not quizzable** as normal vocabulary (contrary to PR #41's intent).
2. When they reached the Relearn pool they arrived **without** the `QUIZ_TYPE_ETYMOLOGY_ORIGIN` card kind + origin header, so the frontend rendered them as plain **ungrouped** cards instead of folding them into an origin-family group.

Root cause: `LoadAllWords` (and, via it, the relearn vocab index) loaded only story indexes, flashcard indexes, and definitions books. The only reader that surfaces an etymology notebook's embedded `definitions:` block never fed the loaders. Words embedded in story/flashcard files were already loaded elsewhere and grouped fine — the gap was specifically the **etymology-notebook** ones.

## Fix

- New reader method `Reader.ReadEtymologyNotebookDefinitions()` scans **only** etymology indexes and returns their embedded, origin-bearing definitions (story/flashcard-embedded etymology defs are already loaded by their own loaders, so they are intentionally out of scope here). `NotebookName` is set to the etymology book **ID** so the learning-log write/read path stays symmetric.
- `LoadAllWords` now ingests those definitions as ordinary `FreeformCard`s. Because `relearnVocabIndex` is built from `LoadAllWords`, this single change makes the words both **quizzable** (freeform) and **resolvable** as Relearn misses. `buildWordDetail(..., originMap)` resolves each `origin_parts` ref against the etymology origin map, so `primaryOriginPart` returns the origin and the miss enters the **existing** `ETYMOLOGY_ORIGIN` grouping branch in `LoadRelearnPool`.
- **No frontend or grading changes.** Words flow through the existing paths unchanged; grading stays the ordinary recognition grader (one series per word per mode).

## Canonical-dedup rule (learning-history-invariants L1/L4 — one log series per word)

A given expression could exist both embedded in an etymology notebook and in a definitions/story/flashcard book. To avoid a parallel learning-log series:

> **A story / flashcard / definitions entry always wins.** An etymology-notebook copy is added **only when no other loader already provides that expression**, deduped case-insensitively on the canonical expression (Definition-precedence, matching the definitions-book loader).

So a word present in both keeps a single canonical card, and therefore a single learning-log series. Read and write paths stay symmetric (L2): `NotebookName` is the etymology book ID (the same key the learning-history file is named after and the relearn candidate matches on). Skip/exclude (`skipped_at`) and grade paths are untouched.

## How verified

`go build ./...`, `go vet ./...`, and `go test ./...` are green. Added Go tests driving the real code paths against a **synthetic, realistically-shaped** etymology notebook (legacy wrapped shape embedding a `definitions:` block whose `origin_parts` reference `origins:` declared in the same notebook; generic roots `dict` → `dictate`/`predict`, no personal data):

- `TestLoadAllWords_IncludesEtymologyNotebookWord` — the embedded word becomes an ordinary vocabulary card (quizzable) with its origin resolved and a primary origin present.
- `TestLoadAllWords_DedupEtymologyVsDefinitions` — a word in both an etymology notebook and a definitions book loads exactly once; the definitions-book entry wins (one series).
- `TestLoadRelearnPool_EtymologyNotebookWordGroups` — a missed etymology-notebook word enters the pool as a `QUIZ_TYPE_ETYMOLOGY_ORIGIN` card with `origin_text`/`origin_meaning`/`english_forms`, so the frontend groups it by origin.

## Needs real-data verification by the user

The user's real etymology notebooks are private and not in this environment, so the code path was exercised against synthetic data only. **Please run one of your dedicated etymology notebooks end-to-end**: confirm its embedded words now appear in the freeform vocabulary quiz, and that missing one surfaces it grouped under its origin in Relearn (not as an ungrouped card), with no duplicate log series for any word that also lives in a definitions/story/flashcard book.

**Do not merge until you have verified against your real data.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)